### PR TITLE
Run Klaus Dormann's test suite

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -397,9 +397,6 @@ impl Execute for System {
 
         if condition {
           self.registers.pc.offset(offset);
-          if self.registers.pc.address() != 0x09fd {
-            println!("branching to {:04X}", self.registers.pc.address());
-          }
         }
 
         Ok(())

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -97,13 +97,11 @@ impl Execute for System {
       0x48 => {
         // PHA
         self.push(self.registers.a);
-        println!("PHA: {:08b}", self.registers.a);
         Ok(())
       }
       0x08 => {
         // PHP
         self.push(self.registers.sr.get() | flags::BREAK);
-        println!("PHP: {:08b}", self.registers.sr.get() | flags::BREAK);
         Ok(())
       }
       0x68 => {
@@ -111,14 +109,12 @@ impl Execute for System {
         let value = self.pop();
         self.registers.a = value;
         self.registers.sr.set_nz(value);
-        println!("PLA: {:08b}", value);
         Ok(())
       }
       0x28 => {
         // PLP
         let status = self.pop();
         self.registers.sr.load(status);
-        println!("PLP: {:08b}", self.registers.sr.get());
         Ok(())
       }
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -97,22 +97,26 @@ impl Execute for System {
       0x48 => {
         // PHA
         self.push(self.registers.a);
+        println!("PHA: {:08b}", self.registers.a);
         Ok(())
       }
       0x08 => {
         // PHP
-        self.push(self.registers.sr.get());
+        self.push(self.registers.sr.get() | flags::BREAK);
+        println!("PHP: {:08b}", self.registers.sr.get() | flags::BREAK);
         Ok(())
       }
       0x68 => {
         // PLA
         self.registers.a = self.pop();
+        println!("PLA: {:08b}", self.registers.a);
         Ok(())
       }
       0x28 => {
         // PLP
         let status = self.pop();
         self.registers.sr.load(status);
+        println!("PLP: {:08b}", self.registers.sr.get());
         Ok(())
       }
 
@@ -329,7 +333,7 @@ impl Execute for System {
       0x00 => {
         // BRK
         self.registers.pc.increment();
-        self.interrupt(true);
+        self.interrupt(true, true);
         Ok(())
       }
       0x4C | 0x6C => {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -15,6 +15,7 @@ impl Execute for System {
         let value = self.fetch_operand_value(opcode);
         self.registers.a = value;
         self.registers.sr.set_nz(value);
+        println!("LDA ${:02X}", value);
         Ok(())
       }
 
@@ -115,6 +116,7 @@ impl Execute for System {
         // PLP
         let status = self.pop();
         self.registers.sr.load(status);
+        println!("PLP ${:08b}", status);
         Ok(())
       }
 
@@ -230,6 +232,7 @@ impl Execute for System {
         // EOR
         let value = self.fetch_operand_value(opcode);
         self.registers.a ^= value;
+        println!("EOR!!!");
         self.registers.sr.set_nz(self.registers.a);
         Ok(())
       }
@@ -253,6 +256,7 @@ impl Execute for System {
       0xC1 | 0xC5 | 0xC9 | 0xCD | 0xD1 | 0xD5 | 0xD9 | 0xDD => {
         // CMP
         let value = self.fetch_operand_value(opcode);
+        println!("CMP A: {:02X} val: {:02X}", self.registers.a, value);
         self.registers.alu_compare(self.registers.a, value);
         Ok(())
       }
@@ -330,6 +334,7 @@ impl Execute for System {
       // === CONTROL ===
       0x00 => {
         // BRK
+        println!("BRKing at {:04X}", self.registers.pc.address());
         self.registers.pc.increment();
         self.interrupt(true, true);
         Ok(())
@@ -344,6 +349,8 @@ impl Execute for System {
           }
           _ => unreachable!(),
         };
+
+        println!("JMPing to {:04X}", address);
 
         self.registers.pc.load(address);
         Ok(())
@@ -361,12 +368,14 @@ impl Execute for System {
         self.registers.sr.load(status);
         let dest = self.pop_word();
         self.registers.pc.load(dest);
+        println!("RTI: {:04X} with status {:08b}", dest, status);
         Ok(())
       }
       0x60 => {
         // RTS
         let dest = self.pop_word().wrapping_add(1);
         self.registers.pc.load(dest);
+        println!("RTS: {:04X}", dest);
         Ok(())
       }
 
@@ -388,6 +397,9 @@ impl Execute for System {
 
         if condition {
           self.registers.pc.offset(offset);
+          if self.registers.pc.address() != 0x09fd {
+            println!("branching to {:04X}", self.registers.pc.address());
+          }
         }
 
         Ok(())
@@ -413,6 +425,8 @@ impl Execute for System {
           0x78 => flags::INTERRUPT, // SEI
           _ => unreachable!(),
         });
+
+        println!("set flag {:08b}", self.registers.sr.get());
 
         Ok(())
       }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -108,8 +108,10 @@ impl Execute for System {
       }
       0x68 => {
         // PLA
-        self.registers.a = self.pop();
-        println!("PLA: {:08b}", self.registers.a);
+        let value = self.pop();
+        self.registers.a = value;
+        self.registers.sr.set_nz(value);
+        println!("PLA: {:08b}", value);
         Ok(())
       }
       0x28 => {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -15,7 +15,6 @@ impl Execute for System {
         let value = self.fetch_operand_value(opcode);
         self.registers.a = value;
         self.registers.sr.set_nz(value);
-        println!("LDA ${:02X}", value);
         Ok(())
       }
 
@@ -116,7 +115,6 @@ impl Execute for System {
         // PLP
         let status = self.pop();
         self.registers.sr.load(status);
-        println!("PLP ${:08b}", status);
         Ok(())
       }
 
@@ -232,7 +230,6 @@ impl Execute for System {
         // EOR
         let value = self.fetch_operand_value(opcode);
         self.registers.a ^= value;
-        println!("EOR!!!");
         self.registers.sr.set_nz(self.registers.a);
         Ok(())
       }
@@ -256,7 +253,6 @@ impl Execute for System {
       0xC1 | 0xC5 | 0xC9 | 0xCD | 0xD1 | 0xD5 | 0xD9 | 0xDD => {
         // CMP
         let value = self.fetch_operand_value(opcode);
-        println!("CMP A: {:02X} val: {:02X}", self.registers.a, value);
         self.registers.alu_compare(self.registers.a, value);
         Ok(())
       }
@@ -334,7 +330,6 @@ impl Execute for System {
       // === CONTROL ===
       0x00 => {
         // BRK
-        println!("BRKing at {:04X}", self.registers.pc.address());
         self.registers.pc.increment();
         self.interrupt(true, true);
         Ok(())
@@ -349,8 +344,6 @@ impl Execute for System {
           }
           _ => unreachable!(),
         };
-
-        println!("JMPing to {:04X}", address);
 
         self.registers.pc.load(address);
         Ok(())
@@ -368,14 +361,12 @@ impl Execute for System {
         self.registers.sr.load(status);
         let dest = self.pop_word();
         self.registers.pc.load(dest);
-        println!("RTI: {:04X} with status {:08b}", dest, status);
         Ok(())
       }
       0x60 => {
         // RTS
         let dest = self.pop_word().wrapping_add(1);
         self.registers.pc.load(dest);
-        println!("RTS: {:04X}", dest);
         Ok(())
       }
 
@@ -422,8 +413,6 @@ impl Execute for System {
           0x78 => flags::INTERRUPT, // SEI
           _ => unreachable!(),
         });
-
-        println!("set flag {:08b}", self.registers.sr.get());
 
         Ok(())
       }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -44,7 +44,7 @@ impl Fetch for System {
       0x01 | 0x03 => {
         // (Indirect,X)
         let base = self.fetch();
-        let pointer = base as u16 + self.registers.x as u16;
+        let pointer = (base as u16 + self.registers.x as u16) & 0xFF;
         self.read_word(pointer)
       }
       0x04 | 0x05 | 0x06 | 0x07 => self.fetch() as u16, // Zero page

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -61,15 +61,15 @@ impl Fetch for System {
       0x14 | 0x15 => {
         // Zero page,X
         let base = self.fetch();
-        base as u16 + self.registers.x as u16
+        (base as u16 + self.registers.x as u16) & 0xFF
       }
       0x16 | 0x17 => {
         // Zero page,X or Zero page,Y
         let base = self.fetch();
         if opcode & 0xC0 == 0x80 {
-          base as u16 + self.registers.y as u16
+          (base as u16 + self.registers.y as u16) & 0xFF
         } else {
-          base as u16 + self.registers.x as u16
+          (base as u16 + self.registers.x as u16) & 0xFF
         }
       }
       0x19 | 0x1B => {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -61,15 +61,15 @@ impl Fetch for System {
       0x14 | 0x15 => {
         // Zero page,X
         let base = self.fetch();
-        (base + self.registers.x) as u16
+        base as u16 + self.registers.x as u16
       }
       0x16 | 0x17 => {
         // Zero page,X or Zero page,Y
         let base = self.fetch();
         if opcode & 0xC0 == 0x80 {
-          (base + self.registers.y) as u16
+          base as u16 + self.registers.y as u16
         } else {
-          (base + self.registers.x) as u16
+          base as u16 + self.registers.x as u16
         }
       }
       0x19 | 0x1B => {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -44,7 +44,7 @@ impl Fetch for System {
       0x01 | 0x03 => {
         // (Indirect,X)
         let base = self.fetch();
-        let pointer = (base + self.registers.x) as u16;
+        let pointer = base as u16 + self.registers.x as u16;
         self.read_word(pointer)
       }
       0x04 | 0x05 | 0x06 | 0x07 => self.fetch() as u16, // Zero page

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@
 use libnoentiendo::{
   platform::{Platform, TextPlatform, WinitPlatform},
   systems::pet::PetSystemRoms,
-  systems::{BrookeSystemFactory, EasySystemFactory, PetSystemFactory, SystemFactory},
+  systems::{
+    BrookeSystemFactory, EasySystemFactory, KlausSystemFactory, PetSystemFactory, SystemFactory,
+  },
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -40,6 +42,7 @@ fn main() {
   let system = match args.system.as_str() {
     "brooke" => BrookeSystemFactory::create(romfile.unwrap(), platform.provider()),
     "easy" => EasySystemFactory::create(romfile.unwrap(), platform.provider()),
+    "klaus" => KlausSystemFactory::create(romfile.unwrap(), platform.provider()),
     "pet" => PetSystemFactory::create(PetSystemRoms::from_disk(), platform.provider()),
     _ => panic!("Unknown system"),
   };

--- a/src/memory/block.rs
+++ b/src/memory/block.rs
@@ -28,7 +28,11 @@ impl BlockMemory {
     let file_data = file.get_data();
 
     if file_data.len() > size {
-      panic!("File of size {} is too large for memory block of size {}", file_data.len(), size);
+      panic!(
+        "File of size {} is too large for memory block of size {}",
+        file_data.len(),
+        size
+      );
     }
 
     for i in 0..file_data.len() {

--- a/src/platform/text.rs
+++ b/src/platform/text.rs
@@ -20,6 +20,8 @@ impl Platform for TextPlatform {
   fn run(&mut self, mut system: System) {
     system.reset();
 
+    system.registers.pc.load(0x0400); // Klaus tests
+
     let mut last_tick = Instant::now();
     let mut last_report = last_tick;
 

--- a/src/platform/text.rs
+++ b/src/platform/text.rs
@@ -21,6 +21,8 @@ impl Platform for TextPlatform {
     system.reset();
 
     let mut last_tick = Instant::now();
+    let mut last_report = last_tick;
+
     loop {
       let duration = system.tick();
       let now = Instant::now();
@@ -29,6 +31,12 @@ impl Platform for TextPlatform {
         thread::sleep(duration - elapsed);
       }
       last_tick = now;
+
+      if now - last_report > std::time::Duration::from_secs(1) {
+        let pc = system.registers.pc.address();
+        println!("Program Counter: {:02x}", pc);
+        last_report = now;
+      }
     }
   }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -12,8 +12,8 @@ pub mod flags {
   pub const ZERO: u8 = 0b00000010;
   pub const INTERRUPT: u8 = 0b00000100;
   pub const DECIMAL: u8 = 0b00001000;
-  pub const _BREAK: u8 = 0b00010000;
-  pub const _UNUSED: u8 = 0b00100000;
+  pub const BREAK: u8 = 0b00010000;
+  pub const UNUSED: u8 = 0b00100000;
   pub const OVERFLOW: u8 = 0b01000000;
   pub const NEGATIVE: u8 = 0b10000000;
 }
@@ -104,7 +104,7 @@ impl StatusRegister {
   }
 
   pub fn load(&mut self, value: u8) {
-    self.value = value;
+    self.value = value | flags::UNUSED | flags::BREAK;
   }
 
   pub fn get(&self) -> u8 {

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -125,30 +125,77 @@ pub trait ALU {
 
 impl ALU for Registers {
   fn alu_add(&mut self, value: u8) {
-    if self.sr.read(flags::DECIMAL) {
-      todo!("decimal mode not yet implemented!");
+    if !self.sr.read(flags::DECIMAL) {
+      let sum = (self.a as u16)
+        .wrapping_add(value as u16)
+        .wrapping_add(self.sr.read(flags::CARRY) as u16);
+
+      self.sr.write(flags::CARRY, sum > 0xFF);
+      self.sr.write(
+        flags::OVERFLOW,
+        !(self.a ^ value) & (self.a ^ sum as u8) & 0x80 != 0,
+      );
+
+      let sum = sum as u8;
+      self.sr.set_nz(sum);
+      self.a = sum;
+    } else {
+      let mut lsd = (self.a & 0x0F) + (value & 0x0F) + self.sr.read(flags::CARRY) as u8;
+      let mut msd = ((self.a & 0xF0) as u16) + ((value & 0xF0) as u16);
+
+      if lsd > 0x09 {
+        msd += 0x10;
+        lsd += 0x06;
+        lsd &= 0x0F;
+      }
+
+      if msd > 0x90 {
+        msd += 0x60;
+      }
+
+      self.sr.write(flags::CARRY, (msd & 0xFF00) != 0);
+
+      let sum = (msd as u8) | (lsd as u8);
+      self.sr.set_nz(sum);
+      self.a = sum;
     }
-
-    let sum = (self.a as u16)
-      .wrapping_add(value as u16)
-      .wrapping_add(self.sr.read(flags::CARRY) as u16);
-
-    self.sr.write(flags::CARRY, sum > 0xFF);
-    self.sr.write(
-      flags::OVERFLOW,
-      !(self.a ^ value) & (self.a ^ sum as u8) & 0x80 != 0,
-    );
-
-    self.a = sum as u8;
-    self.sr.set_nz(self.a);
   }
 
   fn alu_subtract(&mut self, value: u8) {
-    if self.sr.read(flags::DECIMAL) {
-      todo!("decimal mode not yet implemented!");
-    }
+    if !self.sr.read(flags::DECIMAL) {
+      let sum = (self.a as u16)
+        .wrapping_add(!value as u16)
+        .wrapping_add(self.sr.read(flags::CARRY) as u16);
 
-    self.alu_add(!value);
+      self.sr.write(flags::CARRY, sum > 0xFF);
+      self.sr.write(
+        flags::OVERFLOW,
+        (self.a ^ value) & (self.a ^ sum as u8) & 0x80 != 0,
+      );
+
+      let sum = sum as u8;
+      self.sr.set_nz(sum);
+      self.a = sum;
+    } else {
+      let mut lsd = (self.a & 0x0F) + (0x09 - (value & 0x0F)) + self.sr.read(flags::CARRY) as u8;
+      let mut msd = ((self.a & 0xF0) as u16) + ((0x90 - (value & 0xF0)) as u16);
+
+      if lsd > 0x09 {
+        msd += 0x10;
+        lsd += 0x06;
+        lsd &= 0x0F;
+      }
+
+      if msd > 0x90 {
+        msd += 0x60;
+      }
+
+      self.sr.write(flags::CARRY, (msd & 0xFF00) != 0);
+
+      let sum = (msd as u8) | (lsd as u8);
+      self.sr.set_nz(sum);
+      self.a = sum;
+    }
   }
 
   fn alu_compare(&mut self, register: u8, value: u8) {

--- a/src/system.rs
+++ b/src/system.rs
@@ -77,21 +77,11 @@ pub trait InterruptHandler {
 
 impl InterruptHandler for System {
   fn interrupt(&mut self, maskable: bool, break_instr: bool) {
-    println!(
-      "Interrupt, maskable: {}, break: {}, status register {:08b}",
-      maskable,
-      break_instr,
-      self.registers.sr.get()
-    );
-
     if maskable && !break_instr && self.registers.sr.read(flags::INTERRUPT) {
-      println!("ignoring, I flag is set");
       return;
     }
 
     self.push_word(self.registers.pc.address());
-
-    println!("pushing status register {:08b}", self.registers.sr.get());
 
     if break_instr {
       self.push(self.registers.sr.get() | flags::BREAK);
@@ -105,8 +95,6 @@ impl InterruptHandler for System {
       false => self.read_word(0xFFFA),
       true => self.read_word(0xFFFE),
     };
-
-    println!("Interrupt destination: {:04X}", dest);
 
     self.registers.pc.load(dest);
   }

--- a/src/system.rs
+++ b/src/system.rs
@@ -60,13 +60,13 @@ impl Stack for System {
   }
 
   fn push_word(&mut self, value: u16) {
-    self.push((value & 0xFF) as u8);
     self.push((value >> 8) as u8);
+    self.push((value & 0xFF) as u8);
   }
 
   fn pop_word(&mut self) -> u16 {
-    let hi = self.pop();
     let lo = self.pop();
+    let hi = self.pop();
     (hi as u16) << 8 | lo as u16
   }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -49,13 +49,13 @@ pub trait Stack {
 
 impl Stack for System {
   fn push(&mut self, value: u8) {
-    self.registers.sp.push();
     self.write(self.registers.sp.address(), value);
+    self.registers.sp.push();
   }
 
   fn pop(&mut self) -> u8 {
-    let value = self.read(self.registers.sp.address());
     self.registers.sp.pop();
+    let value = self.read(self.registers.sp.address());
     value
   }
 

--- a/src/systems/klaus.rs
+++ b/src/systems/klaus.rs
@@ -1,0 +1,17 @@
+use crate::memory::{BlockMemory, BranchMemory, RomFile};
+use crate::platform::PlatformProvider;
+use crate::system::System;
+use crate::systems::SystemFactory;
+use std::sync::Arc;
+
+pub struct KlausSystemFactory {}
+
+impl SystemFactory<RomFile> for KlausSystemFactory {
+  fn create(rom: RomFile, _platform: Arc<dyn PlatformProvider>) -> System {
+    let rom = BlockMemory::from_file(0x10000, rom);
+
+    let memory = BranchMemory::new().map(0x0000, Box::new(rom));
+
+    System::new(Box::new(memory), 0)
+  }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 
 pub mod brooke;
 pub mod easy;
+pub mod klaus;
 pub mod pet;
 
 pub use brooke::BrookeSystemFactory;
 pub use easy::EasySystemFactory;
+pub use klaus::KlausSystemFactory;
 pub use pet::PetSystemFactory;
 
 pub trait SystemFactory<RomRegistry> {


### PR DESCRIPTION
* Fixed issue with the stack pointer being incremented and decremented at the wrong time
* Always set the BREAK flag except when an interrupt is fired
* Set the NZ flags when pulling (PLA) from the stack into the accumulator
* Fix the endianness of 16-bit values pushed onto the stack (push high *then* low)
* Go through the interrupt routine on a BRK instruction even if the interrupt flag is set
* Fix an overflow exception for zero-page and indirect,X zero-page addressing, and ensure addresses wrap around within the zero page address space
* Implement addition and subtraction in decimal mode