### PR TITLE
Add tests to the memory implementations

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -11,6 +11,7 @@ pub use null::NullMemory;
 pub use ports::{NullPort, Port};
 
 /// Represents the state of the interrupts on the system.
+#[derive(Debug, PartialEq, Eq)]
 pub enum ActiveInterrupt {
   /// No interrupts are active.
   None,
@@ -22,6 +23,7 @@ pub enum ActiveInterrupt {
 
 /// Information about the system that Memory implementations can use to
 /// determine if an interrupt should be triggered.
+#[derive(Debug, Default)]
 pub struct SystemInfo {
   pub cycles_per_second: u64,
   pub cycle_count: u64,

--- a/src/memory/null.rs
+++ b/src/memory/null.rs
@@ -46,3 +46,16 @@ impl Memory for NullMemory {
     ActiveInterrupt::None
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_null() {
+    let mut memory = NullMemory::new();
+    assert_eq!(memory.read(0x0000), 0);
+    memory.write(0x0000, 0x12);
+    assert_eq!(memory.read(0x0000), 0);
+  }
+}

--- a/src/memory/ports.rs
+++ b/src/memory/ports.rs
@@ -58,3 +58,16 @@ impl Port for NullPort {
 
   fn reset(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_null() {
+    let mut port = NullPort::new();
+    assert_eq!(port.read(), 0);
+    port.write(0x12);
+    assert_eq!(port.read(), 0);
+  }
+}


### PR DESCRIPTION
Adds tests to:
* BlockMemory
* BranchMemory
* NullMemory
* PIA (MOS 6520)
* VIA (MOS 6522)

Note that the PIA and VIA implementations are incomplete (e.g. they lack control signals), so the tests only cover implemented functionality.