### PR TITLE
6510 Port, Bankable Memory, Commodore 64 Memory Banking

### DIFF
--- a/src/memory/banked.rs
+++ b/src/memory/banked.rs
@@ -1,0 +1,65 @@
+use std::{cell::Cell, rc::Rc};
+
+use super::{ActiveInterrupt, Memory, SystemInfo};
+
+pub struct BankedMemory {
+  banks: Vec<Box<dyn Memory>>,
+  active: Rc<Cell<usize>>,
+}
+
+impl BankedMemory {
+  pub fn new(active: Rc<Cell<usize>>) -> Self {
+    Self {
+      banks: Vec::new(),
+      active,
+    }
+  }
+
+  pub fn bank(mut self, memory: Box<dyn Memory>) -> Self {
+    self.banks.push(memory);
+
+    self
+  }
+}
+
+impl Memory for BankedMemory {
+  fn read(&mut self, address: u16) -> u8 {
+    match self.banks.get_mut(self.active.get()) {
+      Some(memory) => memory.read(address),
+      None => panic!("Invalid bank {} selected", self.active.get()),
+    }
+  }
+
+  fn write(&mut self, address: u16, value: u8) {
+    match self.banks.get_mut(self.active.get()) {
+      Some(memory) => memory.write(address, value),
+      None => panic!("Invalid bank {} selected", self.active.get()),
+    }
+  }
+
+  fn reset(&mut self) {
+    for memory in self.banks.iter_mut() {
+      memory.reset();
+    }
+  }
+
+  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+    let mut highest = ActiveInterrupt::None;
+
+    for mapped in &mut self.banks {
+      let interrupt = mapped.poll(info);
+
+      match interrupt {
+        ActiveInterrupt::None => (),
+        ActiveInterrupt::NMI => {
+          highest = ActiveInterrupt::NMI;
+        }
+        ActiveInterrupt::IRQ => {
+          highest = ActiveInterrupt::IRQ;
+        }
+      }
+    }
+
+    highest
+  }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,12 +2,14 @@ mod banked;
 mod block;
 mod branch;
 pub mod interface;
+mod mos6510;
 mod null;
 pub mod ports;
 
 pub use banked::BankedMemory;
 pub use block::BlockMemory;
 pub use branch::BranchMemory;
+pub use mos6510::Mos6510Port;
 pub use null::NullMemory;
 pub use ports::{NullPort, Port};
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,9 +1,11 @@
+mod banked;
 mod block;
 mod branch;
 pub mod interface;
 mod null;
 pub mod ports;
 
+pub use banked::BankedMemory;
 pub use block::BlockMemory;
 pub use branch::BranchMemory;
 pub use null::NullMemory;

--- a/src/memory/mos6510.rs
+++ b/src/memory/mos6510.rs
@@ -1,0 +1,61 @@
+use super::{ActiveInterrupt, Memory, Port, SystemInfo};
+
+/// Represents the port built into a MOS 6510 processor, mapped to memory addresses 0x0000 (for the DDR) and 0x0001 (for the port itself).
+pub struct Mos6510Port {
+  /// The port itself.
+  port: Box<dyn Port>,
+
+  /// If the DDR is write, the current written value.
+  writes: u8,
+
+  /// Data direction register. Each bit controls whether the line is an input (0) or output (1)
+  ddr: u8,
+}
+
+impl Mos6510Port {
+  /// Create a new MOS 6510 port with the given port.
+  pub fn new(port: Box<dyn Port>) -> Self {
+    Self {
+      port,
+      writes: 0,
+      ddr: 0xFF,
+    }
+  }
+}
+
+impl Memory for Mos6510Port {
+  fn read(&mut self, address: u16) -> u8 {
+    match address % 2 {
+      0 => self.ddr,
+      1 => (self.port.read() & !self.ddr) | (self.writes & self.ddr),
+      _ => unreachable!(),
+    }
+  }
+
+  fn write(&mut self, address: u16, value: u8) {
+    match address % 2 {
+      0 => {
+        println!("6510 DDR: {:02x}", value);
+        self.ddr = value;
+        self.port.write(self.writes & self.ddr);
+      }
+      1 => {
+        println!("6510 writes: {:02x}", value);
+        self.writes = value;
+        self.port.write(value & self.ddr);
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  fn reset(&mut self) {
+    self.port.reset();
+  }
+
+  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+    match self.port.poll(info) {
+      true => ActiveInterrupt::IRQ,
+      false => ActiveInterrupt::None,
+    }
+  }
+}

--- a/src/memory/mos6510.rs
+++ b/src/memory/mos6510.rs
@@ -35,12 +35,10 @@ impl Memory for Mos6510Port {
   fn write(&mut self, address: u16, value: u8) {
     match address % 2 {
       0 => {
-        println!("6510 DDR: {:02x}", value);
         self.ddr = value;
         self.port.write(self.writes & self.ddr);
       }
       1 => {
-        println!("6510 writes: {:02x}", value);
         self.writes = value;
         self.port.write(value & self.ddr);
       }

--- a/src/roms/mod.rs
+++ b/src/roms/mod.rs
@@ -12,6 +12,7 @@ pub use wasm::JsValueLoadable;
 
 /// Represents a predefined, immutable ROM file.
 /// Useful for storing character, BASIC, kernal, etc. ROMs.
+#[derive(Clone, Debug)]
 pub struct RomFile {
   data: Vec<u8>,
 }

--- a/src/systems/c64/keyboard.rs
+++ b/src/systems/c64/keyboard.rs
@@ -1,5 +1,6 @@
 use crate::keyboard::{KeyAdapter, KeyPosition, KeyState, KeySymbol};
 
+/// Keys found on a Commodore 64 keyboard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum C64Keys {
   LeftArrow,
@@ -74,6 +75,8 @@ pub enum C64Keys {
   F7,
 }
 
+/// The keyboard matrix found on a Commodore 64.
+/// Source: https://www.c64-wiki.com/wiki/Keyboard
 pub const KEYBOARD_MAPPING: [[C64Keys; 8]; 8] = {
   use C64Keys::*;
 
@@ -102,6 +105,7 @@ pub const KEYBOARD_MAPPING: [[C64Keys; 8]; 8] = {
   ]
 };
 
+/// An adapter for mapping positions on a standard keyboard to keys on a Commodore 64.
 pub struct C64KeyboardAdapter;
 
 impl KeyAdapter<KeyPosition, C64Keys> for C64KeyboardAdapter {
@@ -191,6 +195,7 @@ impl KeyAdapter<KeyPosition, C64Keys> for C64KeyboardAdapter {
   }
 }
 
+/// An adapter for mapping symbols pressed on a standard keyboard to keys pressed on a Commodore 64.
 pub struct C64SymbolAdapter;
 
 impl KeyAdapter<KeySymbol, C64Keys> for C64SymbolAdapter {

--- a/src/systems/c64/mod.rs
+++ b/src/systems/c64/mod.rs
@@ -260,7 +260,7 @@ impl SystemFactory<C64SystemRoms, C64SystemConfig> for C64SystemFactory {
     let region6 = BankedMemory::new(selector6.clone())
       .bank(Box::new(
         BranchMemory::new()
-          // .map(0x000, Box::new(vic_io))
+          .map(0x000, Box::new(vic_io))
           .map(0x400, Box::new(NullMemory::new())) // TODO: SID
           .map(0x800, Box::new(BlockMemory::ram(0x0400)))
           .map(0xC00, Box::new(cia_1))

--- a/src/systems/c64/mod.rs
+++ b/src/systems/c64/mod.rs
@@ -256,9 +256,12 @@ impl SystemFactory<C64SystemRoms, C64SystemConfig> for C64SystemFactory {
       .bank(Box::new(
         BranchMemory::new()
           // .map(0x000, Box::new(vic_io))
-          .map(0x400, Box::new(NullMemory::new()))
+          .map(0x400, Box::new(NullMemory::new())) // TODO: SID
+          .map(0x800, Box::new(BlockMemory::ram(0x0400)))
           .map(0xC00, Box::new(cia_1))
-          .map(0xD00, Box::new(cia_2)),
+          .map(0xD00, Box::new(cia_2))
+          .map(0xE00, Box::new(NullMemory::new())) // TODO: Expansion card
+          .map(0xF00, Box::new(NullMemory::new())), // TODO: Expansion card
       ))
       .bank(Box::new(BlockMemory::ram(0x1000)))
       .bank(Box::new(BlockMemory::from_file(0x1000, roms.character)));

--- a/src/systems/c64/vic_ii.rs
+++ b/src/systems/c64/vic_ii.rs
@@ -170,7 +170,8 @@ impl VicIIChip {
       let line_data = character[line as usize];
       for pixel in 0..CHAR_WIDTH {
         let color = if line_data & (1 << (CHAR_WIDTH - 1 - pixel)) != 0 {
-          self.get_foreground(address, memory)
+          // self.get_foreground(address, memory)
+          Color::new(255, 0, 0)
         } else {
           VicIIChip::get_color(self.background_color[0])
         };

--- a/src/systems/c64/vic_ii.rs
+++ b/src/systems/c64/vic_ii.rs
@@ -326,7 +326,9 @@ impl Memory for VicIIChipIO {
         chip.row_select = (value & 0b0000_1000) != 0;
         chip.y_scroll = value & 0b0000_0111;
       }
-      0x12 => chip.raster_counter = (chip.raster_counter & 0xFF00) | value as u16,
+      0x12 => {
+        // TODO: set raster comparator to trigger interrupt
+      }
       0x13 => chip.light_pen.0 = value,
       0x14 => chip.light_pen.1 = value,
       0x15 => {
@@ -378,7 +380,9 @@ impl Memory for VicIIChipIO {
     self.chip.borrow_mut().reset();
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+    self.chip.borrow_mut().raster_counter = ((info.cycle_count / 83) % 312) as u16;
+
     ActiveInterrupt::None
   }
 }

--- a/src/systems/c64/vic_ii.rs
+++ b/src/systems/c64/vic_ii.rs
@@ -36,6 +36,7 @@ impl Sprite {
   }
 }
 
+#[allow(dead_code)]
 mod interrupt_bits {
   pub const RASTER: u8 = 1 << 0;
   pub const SPRITE_SPRITE_COLLISION: u8 = 1 << 1;

--- a/src/systems/c64/vic_ii.rs
+++ b/src/systems/c64/vic_ii.rs
@@ -36,6 +36,13 @@ impl Sprite {
   }
 }
 
+mod interrupt_bits {
+  pub const RASTER: u8 = 1 << 0;
+  pub const SPRITE_SPRITE_COLLISION: u8 = 1 << 1;
+  pub const SPRITE_BACKGROUND_COLLISION: u8 = 1 << 2;
+  pub const LIGHT_PEN: u8 = 1 << 3;
+}
+
 pub struct VicIIChip {
   platform: Arc<dyn PlatformProvider>,
   character_rom: Box<dyn Memory>,
@@ -50,11 +57,20 @@ pub struct VicIIChip {
 
   light_pen: (u8, u8), // (x, y)
 
-  raster_counter: u8,
+  raster_counter: u16,
 
-  // TODO
-  control_register_1: u8,
-  control_register_2: u8,
+  interrupts_enabled: u8,
+
+  extended_color_mode: bool,
+  bit_map_mode: bool,
+  multi_color_mode: bool,
+  display_enable: bool,
+  res_bit: bool,
+
+  row_select: bool,
+  column_select: bool,
+  x_scroll: u8,
+  y_scroll: u8,
 
   // drawing
   last_draw_clock: u64,
@@ -77,9 +93,17 @@ impl VicIIChip {
       border_color: 0,
       light_pen: (0, 0),
       raster_counter: 0,
-      control_register_1: 0,
-      control_register_2: 0,
+      interrupts_enabled: 0,
       last_draw_clock: 0,
+      extended_color_mode: false,
+      bit_map_mode: false,
+      multi_color_mode: false,
+      display_enable: false,
+      res_bit: false,
+      row_select: false,
+      column_select: false,
+      x_scroll: 0,
+      y_scroll: 0,
     }
   }
 
@@ -91,9 +115,17 @@ impl VicIIChip {
     self.border_color = 0;
     self.light_pen = (0, 0);
     self.raster_counter = 0;
-    self.control_register_1 = 0;
-    self.control_register_2 = 0;
+    self.interrupts_enabled = 0;
     self.last_draw_clock = 0;
+    self.extended_color_mode = false;
+    self.bit_map_mode = false;
+    self.multi_color_mode = false;
+    self.display_enable = false;
+    self.res_bit = false;
+    self.row_select = false;
+    self.column_select = false;
+    self.x_scroll = 0;
+    self.y_scroll = 0;
   }
 
   /// Read the value of the screen memory at the given address,
@@ -170,8 +202,7 @@ impl VicIIChip {
       let line_data = character[line as usize];
       for pixel in 0..CHAR_WIDTH {
         let color = if line_data & (1 << (CHAR_WIDTH - 1 - pixel)) != 0 {
-          // self.get_foreground(address, memory)
-          Color::new(255, 0, 0)
+          self.get_foreground(address, memory)
         } else {
           VicIIChip::get_color(self.background_color[0])
         };
@@ -185,6 +216,7 @@ impl VicIIChip {
 }
 
 /// Represents the I/O mapping for the MOS 6560 VIC.
+/// Sources: https://www.c64-wiki.com/wiki/Page_208-211 and http://www.zimmers.net/cbmpics/cbm/c64/vic-ii.txt
 pub struct VicIIChipIO {
   chip: Rc<RefCell<VicIIChip>>,
 }
@@ -214,8 +246,15 @@ impl Memory for VicIIChipIO {
         let shifted = sprite_msb << i;
         acc | shifted
       }),
-      0x11 => chip.control_register_1,
-      0x12 => chip.raster_counter,
+      0x11 => {
+        ((chip.raster_counter & 0x100 >> 8) as u8) << 7
+          | (chip.extended_color_mode as u8) << 6
+          | (chip.bit_map_mode as u8) << 5
+          | (chip.display_enable as u8) << 4
+          | (chip.row_select as u8) << 3
+          | chip.y_scroll & 0b111
+      }
+      0x12 => chip.raster_counter as u8,
       0x13 => chip.light_pen.0,
       0x14 => chip.light_pen.1,
       0x15 => chip
@@ -223,13 +262,19 @@ impl Memory for VicIIChipIO {
         .iter()
         .enumerate()
         .fold(0, |acc, (i, sprite)| acc | ((sprite.enabled as u8) << i)),
-      0x16 => chip.control_register_2,
+      0x16 => {
+        0b1100_0000
+          | (chip.res_bit as u8) << 5
+          | (chip.multi_color_mode as u8) << 4
+          | (chip.column_select as u8) << 3
+          | chip.x_scroll & 0b111
+      }
       0x17 => chip.sprites.iter().enumerate().fold(0, |acc, (i, sprite)| {
         acc | ((sprite.y_expansion as u8) << i)
       }),
       0x18 => 0, // TODO: memory expansion
       0x19 => 0, // TODO: interrupt flags
-      0x1A => 0, // TODO: interrupt enabled
+      0x1A => 0xF0 | chip.interrupts_enabled,
       0x1B => chip.sprites.iter().enumerate().fold(0, |acc, (i, sprite)| {
         acc | ((sprite.data_priority as u8) << i)
       }),
@@ -243,10 +288,10 @@ impl Memory for VicIIChipIO {
       }),
       0x1E => 0, // TODO: sprite-sprite collision
       0x1F => 0, // TODO: sprite-data collision
-      0x20 => chip.border_color,
-      0x21..=0x24 => chip.background_color[(address % 0x40) as usize - 0x21],
-      0x25..=0x26 => chip.sprite_multicolor[(address % 0x40) as usize - 0x25],
-      0x27..=0x2E => chip.sprites[(address % 0x40) as usize - 0x27].color,
+      0x20 => 0xF0 | chip.border_color,
+      0x21..=0x24 => 0xF0 | chip.background_color[(address % 0x40) as usize - 0x21],
+      0x25..=0x26 => 0xF0 | chip.sprite_multicolor[(address % 0x40) as usize - 0x25],
+      0x27..=0x2E => 0xF0 | chip.sprites[(address % 0x40) as usize - 0x27].color,
       0x2F..=0x3F => 0xFF,
       _ => unreachable!(),
     }
@@ -273,8 +318,14 @@ impl Memory for VicIIChipIO {
           chip.sprites[i].x = (chip.sprites[i].x & 0xFF) | (x_msb as u16) << 8;
         }
       }
-      0x11 => chip.control_register_1 = value,
-      0x12 => chip.raster_counter = value,
+      0x11 => {
+        chip.extended_color_mode = (value & 0b0100_0000) != 0;
+        chip.bit_map_mode = (value & 0b0010_0000) != 0;
+        chip.display_enable = (value & 0b0001_0000) != 0;
+        chip.row_select = (value & 0b0000_1000) != 0;
+        chip.y_scroll = value & 0b0000_0111;
+      }
+      0x12 => chip.raster_counter = (chip.raster_counter & 0xFF00) | value as u16,
       0x13 => chip.light_pen.0 = value,
       0x14 => chip.light_pen.1 = value,
       0x15 => {
@@ -282,7 +333,12 @@ impl Memory for VicIIChipIO {
           chip.sprites[i].enabled = (value & (1 << i)) != 0;
         }
       }
-      0x16 => chip.control_register_2 = value,
+      0x16 => {
+        chip.res_bit = (value & 0b0010_0000) != 0;
+        chip.multi_color_mode = (value & 0b0001_0000) != 0;
+        chip.column_select = (value & 0b0000_1000) != 0;
+        chip.x_scroll = value & 0b0000_0111;
+      }
       0x17 => {
         for i in 0..8 {
           chip.sprites[i].y_expansion = (value & (1 << i)) != 0;
@@ -290,7 +346,7 @@ impl Memory for VicIIChipIO {
       }
       0x18 => {} // TODO: memory expansion
       0x19 => {} // TODO: interrupt flags
-      0x1A => {} // TODO: interrupt enabled
+      0x1A => chip.interrupts_enabled = value & 0x0F,
       0x1B => {
         for i in 0..8 {
           chip.sprites[i].data_priority = (value & (1 << i)) != 0;
@@ -306,8 +362,8 @@ impl Memory for VicIIChipIO {
           chip.sprites[i].x_expansion = (value & (1 << i)) != 0;
         }
       }
-      0x1E => {} // TODO: sprite-sprite collision
-      0x1F => {} // TODO: sprite-data collision
+      0x1E => {}
+      0x1F => {}
       0x20 => chip.border_color = value & 0x0F,
       0x21..=0x24 => chip.background_color[(address % 0x40) as usize - 0x21] = value & 0x0F,
       0x25..=0x26 => chip.sprite_multicolor[(address % 0x40) as usize - 0x25] = value & 0x0F,


### PR DESCRIPTION
* Adds a struct representing the I/O port on the 6510 which delegates to a `Port`
* Adds `BankedMemory`, which allows swapping out the active memory based on the contents of a `Cell`
* Implements memory banking on the Commodore 64
* Implements a few more VIC chip registers