### PR TITLE
Unify the VIA and CIA implementations a bit

### DIFF
--- a/src/memory/interface/mod.rs
+++ b/src/memory/interface/mod.rs
@@ -1,7 +1,0 @@
-pub mod cia;
-pub mod pia;
-pub mod via;
-
-pub use cia::CIA;
-pub use pia::PIA;
-pub use via::VIA;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,8 +1,8 @@
 mod banked;
 mod block;
 mod branch;
-pub mod interface;
 mod mos6510;
+pub mod mos652x;
 mod null;
 pub mod ports;
 

--- a/src/memory/mos652x/cia.rs
+++ b/src/memory/mos652x/cia.rs
@@ -1,5 +1,5 @@
 use crate::memory::{
-  mos652x::{PortRegisters, Timer},
+  mos652x::{PortRegisters, ShiftRegister, Timer},
   ActiveInterrupt, Memory, Port, SystemInfo,
 };
 
@@ -51,25 +51,6 @@ impl TimeClock {
     self.alarm = TimeRegisters::new();
     self.rtc_rate = false;
     self.write_action = false;
-  }
-}
-
-struct ShiftRegister {
-  data: u8,
-  direction: bool, // if 0, the shift register is in input mode; if 1, the shift register is in output mode
-}
-
-impl ShiftRegister {
-  pub fn new() -> Self {
-    Self {
-      data: 0,
-      direction: false,
-    }
-  }
-
-  pub fn reset(&mut self) {
-    self.data = 0;
-    self.direction = false;
   }
 }
 

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -1,0 +1,54 @@
+pub mod cia;
+pub mod pia;
+pub mod via;
+
+pub use cia::Cia;
+pub use pia::Pia;
+pub use via::Via;
+
+use crate::memory::{Port, SystemInfo};
+
+/// A port and its associated registers on the MOS 6522 VIA or MOS 6526 CIA.
+struct PortRegisters {
+  /// The Port implementation that this instance delegates to.
+  port: Box<dyn Port>,
+
+  /// Stores the current value written to the port.
+  writes: u8,
+
+  /// Data Direction Register. Each bit controls whether the line is an input (0) or output (1).
+  ddr: u8,
+
+  /// Latch enable: Present on the MOS 6522 VIA.
+  latch_enabled: bool,
+}
+
+impl PortRegisters {
+  pub fn new(port: Box<dyn Port>) -> Self {
+    Self {
+      port,
+      writes: 0,
+      ddr: 0,
+      latch_enabled: false,
+    }
+  }
+
+  pub fn read(&mut self) -> u8 {
+    (self.port.read() & !self.ddr) | (self.writes & self.ddr)
+  }
+
+  pub fn write(&mut self, value: u8) {
+    self.writes = value;
+    self.port.write(value & self.ddr);
+  }
+
+  pub fn poll(&mut self, info: &SystemInfo) -> bool {
+    self.port.poll(info)
+  }
+
+  pub fn reset(&mut self) {
+    self.ddr = 0;
+
+    self.port.reset();
+  }
+}

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -130,6 +130,7 @@ impl Timer {
       if self.continuous {
         self.counter = self.latch
       } else {
+        self.running = false;
         return false;
       }
     }

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -52,3 +52,142 @@ impl PortRegisters {
     self.port.reset();
   }
 }
+
+/// The manner in which the timer will output signals to the port, if at all.
+enum TimerOutput {
+  /// The timer will not output to the port.
+  None,
+
+  /// The timer will output a single pulse on PB6 or PB7.
+  Pulse,
+
+  /// The timer will output a set number of pulses.
+  PulseCount,
+
+  /// The timer will toggle the output on PB6 or PB7.
+  Toggle,
+}
+
+/// The source of the timer's clock, which controls the rate at which its clock decrements.
+enum TimerClockSource {
+  /// Use the internal system clock.
+  Phi2,
+
+  /// Use pulses on the external CNT pin.
+  Count,
+
+  /// Count underflows of the other timer.
+  Chained,
+
+  /// Count underflows of the other timer, but only if the CNT pin is high.
+  ChainedCount,
+}
+
+/// A timer circuit on the MOS 6522 VIA or MOS 6526 CIA.
+struct Timer {
+  /// The latched value that the counter is reloaded from.
+  latch: u16,
+
+  /// The current value of the timer's internal counter.
+  counter: u16,
+
+  /// Whether the timer's interrupt flag is set.
+  interrupt: bool,
+
+  /// If false, the timer will fire once; if true, it will load the latch into the counter and keep going
+  continuous: bool,
+
+  /// Whether the timer is currently running (decrementing).
+  running: bool,
+
+  /// The manner in which the timer will output to the port.
+  output: TimerOutput,
+
+  /// The source of the timer's clock.
+  clock_source: TimerClockSource,
+}
+
+impl Timer {
+  pub fn new() -> Self {
+    Self {
+      latch: 0,
+      counter: 0,
+      interrupt: false,
+      continuous: false,
+      running: true,
+      output: TimerOutput::None,
+      clock_source: TimerClockSource::Phi2,
+    }
+  }
+
+  pub fn poll(&mut self, _info: &SystemInfo) -> bool {
+    if self.counter == 0 {
+      if self.continuous {
+        self.counter = self.latch
+      } else {
+        return false;
+      }
+    }
+
+    if self.running {
+      self.counter = self.counter.wrapping_sub(1);
+    }
+
+    if self.counter == 0 {
+      self.interrupt = true;
+
+      true
+    } else {
+      false
+    }
+  }
+
+  fn read_cia(&self) -> u8 {
+    let clock_source = match self.clock_source {
+      TimerClockSource::Phi2 => 0b00,
+      TimerClockSource::Count => 0b01,
+      TimerClockSource::Chained => 0b10,
+      TimerClockSource::ChainedCount => 0b11,
+    };
+
+    let output = match self.output {
+      TimerOutput::None => 0b00,
+      TimerOutput::Pulse => 0b01,
+      TimerOutput::Toggle => 0b10,
+      TimerOutput::PulseCount => 0b11,
+    };
+
+    (clock_source << 4) | (!self.continuous as u8) << 3 | (output << 1) | (self.running as u8)
+  }
+
+  fn write_cia(&mut self, value: u8) {
+    self.running = (value & 0b0000_0001) != 0;
+    self.continuous = !((value & 0b0000_1000) != 0);
+
+    self.output = match value & 0b0000_0110 {
+      0b0000_0000 => TimerOutput::None,
+      0b0000_0010 => TimerOutput::Pulse,
+      0b0000_0100 => TimerOutput::Toggle,
+      0b0000_0110 => TimerOutput::PulseCount,
+      _ => unreachable!(),
+    };
+
+    self.clock_source = match value & 0b0011_0000 {
+      0b0000_0000 => TimerClockSource::Phi2,
+      0b0001_0000 => TimerClockSource::Count,
+      0b0010_0000 => TimerClockSource::Chained,
+      0b0011_0000 => TimerClockSource::ChainedCount,
+      _ => unreachable!(),
+    };
+  }
+
+  fn reset(&mut self) {
+    self.latch = 0;
+    self.counter = 0;
+    self.interrupt = false;
+    self.continuous = false;
+    self.running = true;
+    self.output = TimerOutput::None;
+    self.clock_source = TimerClockSource::Phi2;
+  }
+}

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -9,7 +9,7 @@ pub use via::Via;
 use crate::memory::{Port, SystemInfo};
 
 /// A port and its associated registers on the MOS 6522 VIA or MOS 6526 CIA.
-struct PortRegisters {
+pub struct PortRegisters {
   /// The Port implementation that this instance delegates to.
   port: Box<dyn Port>,
 
@@ -54,7 +54,7 @@ impl PortRegisters {
 }
 
 /// The manner in which the timer will output signals to the port, if at all.
-enum TimerOutput {
+pub enum TimerOutput {
   /// The timer will not output to the port.
   None,
 
@@ -69,7 +69,7 @@ enum TimerOutput {
 }
 
 /// The source of the timer's clock, which controls the rate at which its clock decrements.
-enum TimerClockSource {
+pub enum TimerClockSource {
   /// Use the internal system clock.
   Phi2,
 
@@ -84,7 +84,7 @@ enum TimerClockSource {
 }
 
 /// A timer circuit on the MOS 6522 VIA or MOS 6526 CIA.
-struct Timer {
+pub struct Timer {
   /// The latched value that the counter is reloaded from.
   latch: u16,
 
@@ -189,5 +189,34 @@ impl Timer {
     self.running = true;
     self.output = TimerOutput::None;
     self.clock_source = TimerClockSource::Phi2;
+  }
+}
+
+/// The shift register used by the MOS 6522 VIA and MOS 6526 CIA.
+pub struct ShiftRegister {
+  /// The data currently in the shift register.
+  data: u8,
+
+  /// The control register used on the MOS 6522 VIA.
+  control: u8,
+
+  /// The current direction set on the MOS 6526 CIA.
+  /// If 0, the shift register is in input mode; if 1, the shift register is in output mode.
+  direction: bool,
+}
+
+impl ShiftRegister {
+  pub fn new() -> Self {
+    Self {
+      data: 0,
+      control: 0,
+      direction: false,
+    }
+  }
+
+  pub fn reset(&mut self) {
+    self.data = 0;
+    self.control = 0;
+    self.direction = false;
   }
 }

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -170,7 +170,7 @@ impl Timer {
   /// Handle a write to the timer's data register on the MOS 6526 CIA.
   fn write_cia(&mut self, value: u8) {
     self.running = (value & 0b0000_0001) != 0;
-    self.continuous = !((value & 0b0000_1000) != 0);
+    self.continuous = (value & 0b0000_1000) == 0;
 
     self.output = match value & 0b0000_0110 {
       0b0000_0000 => TimerOutput::None,

--- a/src/memory/mos652x/via.rs
+++ b/src/memory/mos652x/via.rs
@@ -1,5 +1,5 @@
 use crate::memory::{
-  mos652x::{PortRegisters, Timer, TimerOutput},
+  mos652x::{PortRegisters, ShiftRegister, Timer, TimerOutput},
   ActiveInterrupt, Memory, Port, SystemInfo,
 };
 
@@ -23,20 +23,6 @@ pub mod sr_control_bits {
   pub const C2_CONTROL: u8 = 0b00011000; // ???
   pub const DDR_SELECT: u8 = 0b00000100; // enable accessing DDR
   pub const C1_CONTROL: u8 = 0b00000011; // interrupt status control
-}
-
-struct ShiftRegister {
-  data: u8,
-  control: u8,
-}
-
-impl ShiftRegister {
-  pub fn new() -> Self {
-    Self {
-      data: 0,
-      control: 0,
-    }
-  }
 }
 
 /// The MOS 6522 Versatile Interface Adapter (VIA).

--- a/src/memory/mos652x/via.rs
+++ b/src/memory/mos652x/via.rs
@@ -129,6 +129,7 @@ impl Memory for Via {
       0x05 => {
         self.t1.latch = (self.t1.latch & 0x00ff) | ((value as u16) << 8);
         self.t1.counter = self.t1.latch;
+        self.t1.running = true;
         self.t1.interrupt = false;
       }
       0x06 => self.t1.latch = (self.t1.latch & 0xff00) | (value as u16),
@@ -138,7 +139,9 @@ impl Memory for Via {
       }
       0x08 => self.t2.latch = (self.t2.latch & 0xff00) | (value as u16),
       0x09 => {
-        self.t2.counter = (self.t2.latch & 0x00ff) | ((value as u16) << 8);
+        self.t2.latch = (self.t2.latch & 0x00ff) | ((value as u16) << 8);
+        self.t2.counter = self.t2.latch;
+        self.t2.running = true;
         self.t2.interrupt = false;
       }
       0x0a => self.sr.data = value,

--- a/src/systems/c64/mod.rs
+++ b/src/systems/c64/mod.rs
@@ -7,8 +7,8 @@ use std::{
 use crate::{
   keyboard::{KeyAdapter, KeyMappingStrategy, SymbolAdapter},
   memory::{
-    interface::CIA, BankedMemory, BlockMemory, BranchMemory, Mos6510Port, NullMemory, NullPort,
-    Port, SystemInfo,
+    mos652x::Cia, BankedMemory, BlockMemory, BranchMemory, Mos6510Port, NullMemory, NullPort, Port,
+    SystemInfo,
   },
   platform::PlatformProvider,
   system::System,
@@ -246,7 +246,7 @@ impl SystemFactory<C64SystemRoms, C64SystemConfig> for C64SystemFactory {
 
     let port_a = C64Cia1PortA::new();
     let keyboard_col = port_a.get_keyboard_row();
-    let cia_1 = CIA::new(
+    let cia_1 = Cia::new(
       Box::new(port_a),
       Box::new(C64Cia1PortB::new(
         keyboard_col,
@@ -255,7 +255,7 @@ impl SystemFactory<C64SystemRoms, C64SystemConfig> for C64SystemFactory {
       )),
     );
 
-    let cia_2 = CIA::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
+    let cia_2 = Cia::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
 
     let region6 = BankedMemory::new(selector6.clone())
       .bank(Box::new(

--- a/src/systems/pet/mod.rs
+++ b/src/systems/pet/mod.rs
@@ -1,5 +1,5 @@
 use crate::keyboard::{KeyAdapter, KeyMappingStrategy, SymbolAdapter};
-use crate::memory::interface::{PIA, VIA};
+use crate::memory::mos652x::{Pia, Via};
 use crate::memory::{BlockMemory, BranchMemory, NullMemory, NullPort, Port, SystemInfo};
 use crate::platform::PlatformProvider;
 use crate::system::System;
@@ -159,9 +159,9 @@ impl SystemFactory<PetSystemRoms, PetSystemConfig> for PetSystemFactory {
 
     let port_a = PetPia1PortA::new();
     let port_b = PetPia1PortB::new(port_a.get_keyboard_row(), config.mapping, platform);
-    let pia1 = PIA::new(Box::new(port_a), Box::new(port_b));
-    let pia2 = PIA::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
-    let via = VIA::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
+    let pia1 = Pia::new(Box::new(port_a), Box::new(port_b));
+    let pia2 = Pia::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
+    let via = Via::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
 
     let kernel_rom = BlockMemory::from_file(0x1000, roms.kernal);
 

--- a/src/systems/vic/mod.rs
+++ b/src/systems/vic/mod.rs
@@ -1,5 +1,5 @@
 use crate::keyboard::{KeyAdapter, KeyMappingStrategy, SymbolAdapter};
-use crate::memory::interface::VIA;
+use crate::memory::mos652x::Via;
 use crate::memory::{BlockMemory, BranchMemory, NullMemory, NullPort, Port, SystemInfo};
 use crate::platform::PlatformProvider;
 use crate::roms::RomFile;
@@ -203,12 +203,12 @@ impl SystemFactory<Vic20SystemRoms, Vic20SystemConfig> for Vic20SystemFactory {
     let main_ram = BlockMemory::ram(0x0E00);
 
     let vic_chip = Rc::new(RefCell::new(VicChip::new(platform.clone())));
-    let via1 = VIA::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
+    let via1 = Via::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
 
     let b = VicVia2PortB::new();
     let a = VicVia2PortA::new(b.get_keyboard_col(), config.mapping, platform);
 
-    let via2 = VIA::new(Box::new(a), Box::new(b));
+    let via2 = Via::new(Box::new(a), Box::new(b));
 
     let basic_rom = BlockMemory::from_file(0x2000, roms.basic);
     let kernel_rom = BlockMemory::from_file(0x2000, roms.kernal);


### PR DESCRIPTION
* Move PIA, VIA, and CIA into a `mos652x` module
* Unify the timers, port registers, shift register, and interrupt registers of the VIA and CIA
* Write tests for the CIA
* Rename to `Pia`, `Via`, and `Cia` to match Rust guidelines