### PR TITLE
Optimize Polling

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -150,12 +150,10 @@ impl Mos6502 {
 
         let info = self.get_info();
 
-        for _ in 0..cycles {
-          match self.memory.poll(1, &info) {
-            ActiveInterrupt::None => (),
-            ActiveInterrupt::NMI => self.interrupt(false, false),
-            ActiveInterrupt::IRQ => self.interrupt(true, false),
-          }
+        match self.memory.poll(cycles as u32, &info) {
+          ActiveInterrupt::None => (),
+          ActiveInterrupt::NMI => self.interrupt(false, false),
+          ActiveInterrupt::IRQ => self.interrupt(true, false),
         }
 
         cycles

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -151,7 +151,7 @@ impl Mos6502 {
         let info = self.get_info();
 
         for _ in 0..cycles {
-          match self.memory.poll(&info) {
+          match self.memory.poll(1, &info) {
             ActiveInterrupt::None => (),
             ActiveInterrupt::NMI => self.interrupt(false, false),
             ActiveInterrupt::IRQ => self.interrupt(true, false),

--- a/src/memory/banked.rs
+++ b/src/memory/banked.rs
@@ -48,11 +48,11 @@ impl Memory for BankedMemory {
     }
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
     let mut highest = ActiveInterrupt::None;
 
     for mapped in &mut self.banks {
-      let interrupt = mapped.poll(info);
+      let interrupt = mapped.poll(cycles, info);
 
       match interrupt {
         ActiveInterrupt::None => (),

--- a/src/memory/block.rs
+++ b/src/memory/block.rs
@@ -72,7 +72,7 @@ impl Memory for BlockMemory {
     }
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> ActiveInterrupt {
     ActiveInterrupt::None
   }
 }

--- a/src/memory/branch.rs
+++ b/src/memory/branch.rs
@@ -66,11 +66,11 @@ impl Memory for BranchMemory {
     }
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
     let mut highest = ActiveInterrupt::None;
 
     for (_, mapped) in &mut self.mapping {
-      let interrupt = mapped.poll(info);
+      let interrupt = mapped.poll(cycles, info);
 
       match interrupt {
         ActiveInterrupt::None => (),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -50,5 +50,5 @@ pub trait Memory {
   /// Poll this memory to see if an interrupt has been triggered.
   /// Implementations may trigger an NMI or IRQ for any
   /// implementation-dependent reason.
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt;
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt;
 }

--- a/src/memory/mos6510.rs
+++ b/src/memory/mos6510.rs
@@ -50,8 +50,8 @@ impl Memory for Mos6510Port {
     self.port.reset();
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
-    match self.port.poll(info) {
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
+    match self.port.poll(cycles, info) {
       true => ActiveInterrupt::IRQ,
       false => ActiveInterrupt::None,
     }

--- a/src/memory/mos652x/cia.rs
+++ b/src/memory/mos652x/cia.rs
@@ -208,18 +208,20 @@ impl Memory for Cia {
     self.interrupts.reset();
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
-    if self.timer_a.poll(info) && (self.interrupts.interrupt_enable & interrupt_bits::TIMER_A) != 0
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
+    if self.timer_a.poll(cycles, info)
+      && (self.interrupts.interrupt_enable & interrupt_bits::TIMER_A) != 0
     {
       return ActiveInterrupt::IRQ;
     }
 
-    if self.timer_b.poll(info) && (self.interrupts.interrupt_enable & interrupt_bits::TIMER_B) != 0
+    if self.timer_b.poll(cycles, info)
+      && (self.interrupts.interrupt_enable & interrupt_bits::TIMER_B) != 0
     {
       return ActiveInterrupt::IRQ;
     }
 
-    if self.a.poll(info) || self.b.poll(info) {
+    if self.a.poll(cycles, info) || self.b.poll(cycles, info) {
       return ActiveInterrupt::IRQ;
     }
 
@@ -274,14 +276,14 @@ mod tests {
     cia.write(0x0E, 0b0000_1001);
 
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
 
     // polling again shouldn't do anything
     for _ in 0..0x20 {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
   }
 
@@ -300,10 +302,10 @@ mod tests {
     cia.write(0x0F, 0b0000_1001);
 
     for _ in 0..0x1233 {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -320,17 +322,19 @@ mod tests {
     // start the timer, and enable continuous operation
     cia.write(0x0E, 0b0000_0001);
 
-    for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
-    }
+    assert_eq!(
+      ActiveInterrupt::None,
+      cia.poll(0x0F, &SystemInfo::default())
+    );
 
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
 
-    for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
-    }
+    assert_eq!(
+      ActiveInterrupt::None,
+      cia.poll(0x0F, &SystemInfo::default())
+    );
 
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -354,10 +358,10 @@ mod tests {
 
     // timer 1 should interrupt first
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -380,7 +384,7 @@ mod tests {
 
     // timer 2 shouldn't trigger an interrupt
     for _ in 0..0x08 {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
 
     // ...but the flag register should be set
@@ -391,9 +395,9 @@ mod tests {
 
     // timer 1 should then trigger an interrupt
     for _ in 0..0x07 {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
 
     // ...and set the corresponding flag, plus the master bit
     assert_eq!(
@@ -406,8 +410,8 @@ mod tests {
 
     // if we let timer 1 run again, it should set the flag again
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, cia.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, cia.poll(1, &SystemInfo::default()));
     }
-    assert_eq!(ActiveInterrupt::IRQ, cia.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, cia.poll(1, &SystemInfo::default()));
   }
 }

--- a/src/memory/mos652x/cia.rs
+++ b/src/memory/mos652x/cia.rs
@@ -140,12 +140,12 @@ impl Memory for Cia {
       0x04 => self.timer_a.latch = (self.timer_a.latch & 0xFF00) | value as u16,
       0x05 => {
         self.timer_a.latch = (self.timer_a.latch & 0x00FF) | ((value as u16) << 8);
-        self.timer_a.counter = self.timer_a.latch;
+        self.timer_a.counter = self.timer_a.latch as i32;
       }
       0x06 => self.timer_b.latch = (self.timer_b.latch & 0xFF00) | value as u16,
       0x07 => {
         self.timer_b.latch = (self.timer_b.latch & 0x00FF) | ((value as u16) << 8);
-        self.timer_b.counter = self.timer_b.latch;
+        self.timer_b.counter = self.timer_b.latch as i32;
       }
       0x08 => match self.time_clock.write_action {
         false => self.time_clock.time.tenth_seconds = value,

--- a/src/memory/mos652x/mod.rs
+++ b/src/memory/mos652x/mod.rs
@@ -138,7 +138,7 @@ impl Timer {
     }
 
     if self.running {
-      self.counter = self.counter - cycles as i32;
+      self.counter -= cycles as i32;
 
       if self.counter <= 0 {
         // The counter underflowed

--- a/src/memory/mos652x/pia.rs
+++ b/src/memory/mos652x/pia.rs
@@ -55,8 +55,8 @@ impl PiaPortRegisters {
   }
 
   /// Poll the underlying port for interrupts.
-  pub fn poll(&mut self, info: &SystemInfo) -> bool {
-    self.port.poll(info)
+  pub fn poll(&mut self, cycles: u32, info: &SystemInfo) -> bool {
+    self.port.poll(cycles, info)
   }
 
   /// Reset the DDR, control register, and underlying port.
@@ -122,9 +122,9 @@ impl Memory for Pia {
     self.b.reset();
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
-    let a = self.a.poll(info);
-    let b = self.b.poll(info);
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
+    let a = self.a.poll(cycles, info);
+    let b = self.b.poll(cycles, info);
 
     if a || b {
       ActiveInterrupt::IRQ

--- a/src/memory/mos652x/via.rs
+++ b/src/memory/mos652x/via.rs
@@ -129,7 +129,7 @@ impl Memory for Via {
       0x04 => self.t1.latch = (self.t1.latch & 0xff00) | (value as u16),
       0x05 => {
         self.t1.latch = (self.t1.latch & 0x00ff) | ((value as u16) << 8);
-        self.t1.counter = self.t1.latch;
+        self.t1.counter = self.t1.latch as i32;
         self.t1.running = true;
         self.t1.interrupt = false;
       }
@@ -141,7 +141,7 @@ impl Memory for Via {
       0x08 => self.t2.latch = (self.t2.latch & 0xff00) | (value as u16),
       0x09 => {
         self.t2.latch = (self.t2.latch & 0x00ff) | ((value as u16) << 8);
-        self.t2.counter = self.t2.latch;
+        self.t2.counter = self.t2.latch as i32;
         self.t2.running = true;
         self.t2.interrupt = false;
       }

--- a/src/memory/mos652x/via.rs
+++ b/src/memory/mos652x/via.rs
@@ -183,16 +183,16 @@ impl Memory for Via {
     self.b.reset();
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
-    if self.t1.poll(info) && self.interrupts.is_enabled(interrupt_bits::T1_ENABLE) {
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
+    if self.t1.poll(cycles, info) && self.interrupts.is_enabled(interrupt_bits::T1_ENABLE) {
       return ActiveInterrupt::IRQ;
     }
 
-    if self.t2.poll(info) && self.interrupts.is_enabled(interrupt_bits::T2_ENABLE) {
+    if self.t2.poll(cycles, info) && self.interrupts.is_enabled(interrupt_bits::T2_ENABLE) {
       return ActiveInterrupt::IRQ;
     }
 
-    if self.a.poll(info) || self.b.poll(info) {
+    if self.a.poll(cycles, info) || self.b.poll(cycles, info) {
       return ActiveInterrupt::IRQ;
     }
 
@@ -244,14 +244,14 @@ mod tests {
     via.write(0x05, 0x00);
 
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
 
     // polling again shouldn't do anything
     for _ in 0..0x20 {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
   }
 
@@ -266,16 +266,16 @@ mod tests {
     via.write(0x08, 0x34);
 
     // polling now shouldn't do anything
-    assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
 
     // timer begins when the high byte is written
     via.write(0x09, 0x12);
 
     for _ in 0..0x1233 {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -293,16 +293,16 @@ mod tests {
     via.write(0x05, 0x00);
 
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
 
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -353,10 +353,10 @@ mod tests {
 
     // timer 1 should interrupt first
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
   }
 
   #[test]
@@ -379,7 +379,7 @@ mod tests {
 
     // timer 2 shouldn't trigger an interrupt
     for _ in 0..0x08 {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
 
     // ...but the flag register should be set
@@ -387,9 +387,9 @@ mod tests {
 
     // timer 1 should then trigger an interrupt
     for _ in 0..0x07 {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
 
     // ...and set the corresponding flag, plus the master bit
     assert_eq!(
@@ -414,8 +414,8 @@ mod tests {
 
     // if we let timer 1 run again, it should set the flag again
     for _ in 0..0x0F {
-      assert_eq!(ActiveInterrupt::None, via.poll(&SystemInfo::default()));
+      assert_eq!(ActiveInterrupt::None, via.poll(1, &SystemInfo::default()));
     }
-    assert_eq!(ActiveInterrupt::IRQ, via.poll(&SystemInfo::default()));
+    assert_eq!(ActiveInterrupt::IRQ, via.poll(1, &SystemInfo::default()));
   }
 }

--- a/src/memory/null.rs
+++ b/src/memory/null.rs
@@ -42,7 +42,7 @@ impl Memory for NullMemory {
 
   fn reset(&mut self) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> ActiveInterrupt {
     ActiveInterrupt::None
   }
 }

--- a/src/memory/ports.rs
+++ b/src/memory/ports.rs
@@ -12,7 +12,7 @@ pub trait Port {
 
   /// Poll the port for interrupts. A port may trigger an interrupt for any
   /// implementation-defined reason.
-  fn poll(&mut self, info: &SystemInfo) -> bool;
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> bool;
 
   /// Reset the port to its initial state, analogous to a system reboot.
   fn reset(&mut self);
@@ -52,7 +52,7 @@ impl Port for NullPort {
     }
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 

--- a/src/systems/basic.rs
+++ b/src/systems/basic.rs
@@ -60,7 +60,7 @@ impl Memory for MappedStdIO {
 
   fn reset(&mut self) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> ActiveInterrupt {
     ActiveInterrupt::None
   }
 }

--- a/src/systems/c64/mod.rs
+++ b/src/systems/c64/mod.rs
@@ -59,7 +59,7 @@ impl Port for C64Cia1PortA {
     self.keyboard_row.set(value);
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 
@@ -117,7 +117,7 @@ impl Port for C64Cia1PortB {
     panic!("Tried to write to keyboard row");
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 
@@ -186,7 +186,7 @@ impl Port for C64BankSwitching {
     self.selectors[5].set(if !self.hiram { 1 } else { 0 });
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 

--- a/src/systems/c64/vic_ii.rs
+++ b/src/systems/c64/vic_ii.rs
@@ -450,7 +450,7 @@ impl Memory for VicIIChipIO {
     self.chip.borrow_mut().reset();
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
     self.chip.borrow_mut().raster_counter = ((info.cycle_count / 83) % 312) as u16;
 
     ActiveInterrupt::None

--- a/src/systems/easy.rs
+++ b/src/systems/easy.rs
@@ -52,7 +52,7 @@ impl Memory for EasyIO {
 
   fn reset(&mut self) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> ActiveInterrupt {
     ActiveInterrupt::None
   }
 }

--- a/src/systems/pet/mod.rs
+++ b/src/systems/pet/mod.rs
@@ -57,7 +57,7 @@ impl Port for PetPia1PortA {
     self.keyboard_row.set(value & 0b1111);
   }
 
-  fn poll(&mut self, info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, info: &SystemInfo) -> bool {
     // let min_elapsed = ((info.cycles_per_second as f64 / 60.0) * (2.0 / 3.0)) as u64;
     let min_elapsed = 0; // TODO: fix
 
@@ -131,7 +131,7 @@ impl Port for PetPia1PortB {
 
   fn write(&mut self, _value: u8) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 

--- a/src/systems/vic/chip.rs
+++ b/src/systems/vic/chip.rs
@@ -493,7 +493,7 @@ impl Memory for VicChipIO {
     self.chip.borrow_mut().reset();
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> ActiveInterrupt {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> ActiveInterrupt {
     ActiveInterrupt::None
   }
 }

--- a/src/systems/vic/mod.rs
+++ b/src/systems/vic/mod.rs
@@ -132,7 +132,7 @@ impl Port for VicVia1PortA {
 
   fn write(&mut self, _value: u8) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 
@@ -170,7 +170,7 @@ impl Port for VicVia2PortB {
     self.keyboard_col.set(value & 0x7F);
   }
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 
@@ -227,7 +227,7 @@ impl Port for VicVia2PortA {
 
   fn write(&mut self, _value: u8) {}
 
-  fn poll(&mut self, _info: &SystemInfo) -> bool {
+  fn poll(&mut self, _cycles: u32, _info: &SystemInfo) -> bool {
     false
   }
 


### PR DESCRIPTION
- Introduce a `cycles` parameter to the `poll()` method, so that memory can be polled once after multiple cycles
- Adapt existing memory and port implementations to respect this parameter
- Remove the `for` loop after instruction execution so that after an opcode is executed, memory is only polled once regardless of how many clocks were used
- Check if `CLOCKS_PER_POLL` (100) cycles have elapsed before polling, to poll less frequently