### PR TITLE
Added enum types for key mapping, platform, and system arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,29 @@ use libnoentiendo::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum SystemArg {
+  Basic,
+  Easy,
+  Klaus,
+  Pet,
+  Vic,
+  C64,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum PlatformArg {
+  Text,
+  Winit,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum KeyMappingArg {
+  Symbolic,
+  Physical,
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Parser, Debug)]
@@ -22,23 +44,22 @@ struct Args {
   rom_path: String,
 
   #[clap(short, long, value_parser)]
-  system: String,
+  system: SystemArg,
 
   #[clap(short, long, value_parser, default_value = "text")]
-  platform: String,
+  platform: PlatformArg,
 
   #[clap(short, long, value_parser, default_value = "symbolic")]
-  key_mapping: String,
+  key_mapping: KeyMappingArg,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
   let args = Args::parse();
 
-  let mut platform: Box<dyn SyncPlatform> = match args.platform.as_str() {
-    "text" => Box::new(TextPlatform::new()),
-    "winit" => Box::new(WinitPlatform::new()),
-    _ => panic!("Unknown platform"),
+  let mut platform: Box<dyn SyncPlatform> = match args.platform {
+    PlatformArg::Text => Box::new(TextPlatform::new()),
+    PlatformArg::Winit => Box::new(WinitPlatform::new()),
   };
 
   let romfile = match args.rom_path.as_str() {
@@ -46,22 +67,21 @@ fn main() {
     _ => Some(libnoentiendo::roms::RomFile::from_file(&args.rom_path)),
   };
 
-  let mapping = match args.key_mapping.as_str() {
-    "symbolic" => KeyMappingStrategy::Symbolic,
-    "physical" => KeyMappingStrategy::Physical,
-    _ => panic!("Unknown key mapping"),
+  let mapping = match args.key_mapping {
+    KeyMappingArg::Symbolic => KeyMappingStrategy::Symbolic,
+    KeyMappingArg::Physical => KeyMappingStrategy::Physical,
   };
 
-  let system = match args.system.as_str() {
-    "basic" => BasicSystemBuilder::build(romfile.unwrap(), (), platform.provider()),
-    "easy" => Easy6502SystemBuilder::build(romfile.unwrap(), (), platform.provider()),
-    "klaus" => KlausSystemBuilder::build(romfile.unwrap(), (), platform.provider()),
-    "pet" => PetSystemBuilder::build(
+  let system = match args.system {
+    SystemArg::Basic => BasicSystemBuilder::build(romfile.unwrap(), (), platform.provider()),
+    SystemArg::Easy => Easy6502SystemBuilder::build(romfile.unwrap(), (), platform.provider()),
+    SystemArg::Klaus => KlausSystemBuilder::build(romfile.unwrap(), (), platform.provider()),
+    SystemArg::Pet => PetSystemBuilder::build(
       PetSystemRoms::from_disk(),
       PetSystemConfig { mapping },
       platform.provider(),
     ),
-    "vic" => Vic20SystemBuilder::build(
+    SystemArg::Vic => Vic20SystemBuilder::build(
       Vic20SystemRoms::from_disk(match romfile {
         Some(_) => Some(args.rom_path.as_str()),
         None => None,
@@ -69,12 +89,11 @@ fn main() {
       Vic20SystemConfig { mapping },
       platform.provider(),
     ),
-    "c64" => C64SystemBuilder::build(
+    SystemArg::C64 => C64SystemBuilder::build(
       C64SystemRoms::from_disk(),
       C64SystemConfig { mapping },
       platform.provider(),
     ),
-    _ => panic!("Unknown system"),
   };
 
   platform.run(system);


### PR DESCRIPTION
I found myself not remembering the possible options for all the types, so I added enum types for some of the args so they appear in the cli (in the `--help`).