### PR TITLE
Remove explicit `Box::new` calls in memory mapping

### DIFF
--- a/src/memory/banked.rs
+++ b/src/memory/banked.rs
@@ -20,8 +20,8 @@ impl BankedMemory {
   }
 
   /// Add a new memory implementation to the banked memory.
-  pub fn bank(mut self, memory: Box<dyn Memory>) -> Self {
-    self.banks.push(memory);
+  pub fn bank(mut self, memory: impl Memory + 'static) -> Self {
+    self.banks.push(Box::new(memory));
 
     self
   }

--- a/src/memory/branch.rs
+++ b/src/memory/branch.rs
@@ -19,8 +19,8 @@ impl BranchMemory {
 
   /// Map a new Memory object to the given starting address in this mapping.
   /// Returns this BranchMemory for chaining.
-  pub fn map(mut self, address: usize, memory: Box<dyn Memory>) -> Self {
-    self.mapping.push((address, memory));
+  pub fn map(mut self, address: usize, memory: impl Memory + 'static) -> Self {
+    self.mapping.push((address, Box::new(memory)));
 
     self
   }
@@ -108,7 +108,7 @@ mod tests {
     block.write(0x00, 0x12);
     block.write(0x34, 0x56);
 
-    let mut memory = BranchMemory::new().map(0, Box::new(block));
+    let mut memory = BranchMemory::new().map(0, block);
 
     assert_eq!(0x12, memory.read(0));
     assert_eq!(0x56, memory.read(0x34));
@@ -126,7 +126,7 @@ mod tests {
     block.write(0x00, 0x12);
     block.write(0x34, 0x56);
 
-    let mut memory = BranchMemory::new().map(0x100, Box::new(block));
+    let mut memory = BranchMemory::new().map(0x100, block);
 
     assert_eq!(0, memory.read(0));
     assert_eq!(0, memory.read(0x34));
@@ -158,9 +158,7 @@ mod tests {
     block2.write(0x00, 0x78);
     block2.write(0x34, 0x9A);
 
-    let mut memory = BranchMemory::new()
-      .map(0x0000, Box::new(block1))
-      .map(0x1000, Box::new(block2));
+    let mut memory = BranchMemory::new().map(0x0000, block1).map(0x1000, block2);
 
     // test reads
     assert_eq!(0x00, memory.read(0x0000));
@@ -197,9 +195,7 @@ mod tests {
     block2.write(0x000, 0x78);
     block2.write(0x134, 0x9A);
 
-    let mut memory = BranchMemory::new()
-      .map(0x0000, Box::new(block1))
-      .map(0x0100, Box::new(block2));
+    let mut memory = BranchMemory::new().map(0x0000, block1).map(0x0100, block2);
 
     // test reads
     assert_eq!(0x12, memory.read(0x0000));

--- a/src/systems/basic.rs
+++ b/src/systems/basic.rs
@@ -75,9 +75,9 @@ impl SystemBuilder<BasicSystem, RomFile, ()> for BasicSystemBuilder {
     let rom = BlockMemory::from_file(0x8000, rom);
 
     let memory = BranchMemory::new()
-      .map(0x0000, Box::new(ram))
-      .map(0x4000, Box::new(io))
-      .map(0x8000, Box::new(rom));
+      .map(0x0000, ram)
+      .map(0x4000, io)
+      .map(0x8000, rom);
 
     let cpu = Mos6502::new(Box::new(memory));
 

--- a/src/systems/c64/mod.rs
+++ b/src/systems/c64/mod.rs
@@ -225,28 +225,28 @@ impl SystemBuilder<C64System, C64SystemRoms, C64SystemConfig> for C64SystemBuild
     // Region 2: 0x1000 - 0x7FFF
     let selector2 = Rc::new(Cell::new(0));
     let region2 = BankedMemory::new(selector2.clone())
-      .bank(Box::new(BlockMemory::ram(0x7000)))
-      .bank(Box::new(NullMemory::new()));
+      .bank(BlockMemory::ram(0x7000))
+      .bank(NullMemory::new());
 
     // Region 3: 0x8000 - 0x9FFF
     let selector3 = Rc::new(Cell::new(0));
     let region3 = BankedMemory::new(selector3.clone())
-      .bank(Box::new(BlockMemory::ram(0x2000)))
-      .bank(Box::new(NullMemory::new())); // TODO: Cartridge Rom Low
+      .bank(BlockMemory::ram(0x2000))
+      .bank(NullMemory::new()); // TODO: Cartridge Rom Low
 
     // Region 4: 0xA000 - 0xBFFF
     let selector4 = Rc::new(Cell::new(0));
     let region4 = BankedMemory::new(selector4.clone())
-      .bank(Box::new(BlockMemory::from_file(0x2000, roms.basic)))
-      .bank(Box::new(BlockMemory::ram(0x2000)))
-      .bank(Box::new(NullMemory::new())) // TODO: Cartridge Rom High
-      .bank(Box::new(NullMemory::new()));
+      .bank(BlockMemory::from_file(0x2000, roms.basic))
+      .bank(BlockMemory::ram(0x2000))
+      .bank(NullMemory::new()) // TODO: Cartridge Rom High
+      .bank(NullMemory::new());
 
     // Region 5: 0xC000 - 0xCFFF
     let selector5 = Rc::new(Cell::new(0));
     let region5 = BankedMemory::new(selector5.clone())
-      .bank(Box::new(BlockMemory::ram(0x1000)))
-      .bank(Box::new(NullMemory::new()));
+      .bank(BlockMemory::ram(0x1000))
+      .bank(NullMemory::new());
 
     // Region 6: 0xD000 - 0xDFFF
     let selector6 = Rc::new(Cell::new(0));
@@ -269,39 +269,39 @@ impl SystemBuilder<C64System, C64SystemRoms, C64SystemConfig> for C64SystemBuild
     let cia_2 = Cia::new(Box::new(NullPort::new()), Box::new(NullPort::new()));
 
     let region6 = BankedMemory::new(selector6.clone())
-      .bank(Box::new(
+      .bank(
         BranchMemory::new()
-          .map(0x000, Box::new(vic_io))
-          .map(0x400, Box::new(NullMemory::new())) // TODO: SID
-          .map(0x800, Box::new(BlockMemory::ram(0x0400)))
-          .map(0xC00, Box::new(cia_1))
-          .map(0xD00, Box::new(cia_2))
-          .map(0xE00, Box::new(NullMemory::new())) // TODO: Expansion card
-          .map(0xF00, Box::new(NullMemory::new())), // TODO: Expansion card
-      ))
-      .bank(Box::new(BlockMemory::ram(0x1000)))
-      .bank(Box::new(BlockMemory::from_file(0x1000, roms.character)));
+          .map(0x000, vic_io)
+          .map(0x400, NullMemory::new()) // TODO: SID
+          .map(0x800, BlockMemory::ram(0x0400))
+          .map(0xC00, cia_1)
+          .map(0xD00, cia_2)
+          .map(0xE00, NullMemory::new()) // TODO: Expansion card
+          .map(0xF00, NullMemory::new()), // TODO: Expansion card
+      )
+      .bank(BlockMemory::ram(0x1000))
+      .bank(BlockMemory::from_file(0x1000, roms.character));
 
     // Region 7: 0xE000 - 0xFFFF
     let selector7 = Rc::new(Cell::new(0));
     let region7 = BankedMemory::new(selector7.clone())
-      .bank(Box::new(BlockMemory::from_file(0x2000, roms.kernal)))
-      .bank(Box::new(BlockMemory::ram(0x2000)))
-      .bank(Box::new(NullMemory::new())); // TODO: Cartidge Rom High
+      .bank(BlockMemory::from_file(0x2000, roms.kernal))
+      .bank(BlockMemory::ram(0x2000))
+      .bank(NullMemory::new()); // TODO: Cartidge Rom High
 
     let bank_switching = C64BankSwitching::new([
       selector2, selector3, selector4, selector5, selector6, selector7,
     ]);
 
     let memory = BranchMemory::new()
-      .map(0x0000, Box::new(Mos6510Port::new(Box::new(bank_switching))))
-      .map(0x0002, Box::new(region1))
-      .map(0x1000, Box::new(region2))
-      .map(0x8000, Box::new(region3))
-      .map(0xA000, Box::new(region4))
-      .map(0xC000, Box::new(region5))
-      .map(0xD000, Box::new(region6))
-      .map(0xE000, Box::new(region7));
+      .map(0x0000, Mos6510Port::new(Box::new(bank_switching)))
+      .map(0x0002, region1)
+      .map(0x1000, region2)
+      .map(0x8000, region3)
+      .map(0xA000, region4)
+      .map(0xC000, region5)
+      .map(0xD000, region6)
+      .map(0xE000, region7);
 
     let cpu = Mos6502::new(Box::new(memory));
 

--- a/src/systems/easy.rs
+++ b/src/systems/easy.rs
@@ -72,12 +72,12 @@ impl SystemBuilder<Easy6502System, RomFile, ()> for Easy6502SystemBuilder {
     let rom = BlockMemory::from_file(0x8000, rom);
 
     let memory = BranchMemory::new()
-      .map(0x0000, Box::new(zero_page))
-      .map(0x00fe, Box::new(io))
-      .map(0x0100, Box::new(stack_ram))
-      .map(0x0200, Box::new(vram))
-      .map(0x0600, Box::new(high_ram))
-      .map(0x8000, Box::new(rom));
+      .map(0x0000, zero_page)
+      .map(0x00fe, io)
+      .map(0x0100, stack_ram)
+      .map(0x0200, vram)
+      .map(0x0600, high_ram)
+      .map(0x8000, rom);
 
     let cpu = Mos6502::new(Box::new(memory));
 

--- a/src/systems/pet/mod.rs
+++ b/src/systems/pet/mod.rs
@@ -182,17 +182,17 @@ impl SystemBuilder<PetSystem, PetSystemRoms, PetSystemConfig> for PetSystemBuild
     let kernel_rom = BlockMemory::from_file(0x1000, roms.kernal);
 
     let memory = BranchMemory::new()
-      .map(0x0000, Box::new(ram))
-      .map(0x8000, Box::new(vram))
-      .map(0x9000, Box::new(expansion_rom_9))
-      .map(0xA000, Box::new(expansion_rom_a))
-      .map(0xB000, Box::new(expansion_rom_b))
-      .map(0xC000, Box::new(basic_rom))
-      .map(0xE000, Box::new(editor_rom))
-      .map(0xE810, Box::new(pia1))
-      .map(0xE820, Box::new(pia2))
-      .map(0xE840, Box::new(via))
-      .map(0xF000, Box::new(kernel_rom));
+      .map(0x0000, ram)
+      .map(0x8000, vram)
+      .map(0x9000, expansion_rom_9)
+      .map(0xA000, expansion_rom_a)
+      .map(0xB000, expansion_rom_b)
+      .map(0xC000, basic_rom)
+      .map(0xE000, editor_rom)
+      .map(0xE810, pia1)
+      .map(0xE820, pia2)
+      .map(0xE840, via)
+      .map(0xF000, kernel_rom);
 
     let cpu = Mos6502::new(Box::new(memory));
 

--- a/src/systems/vic/mod.rs
+++ b/src/systems/vic/mod.rs
@@ -281,22 +281,22 @@ impl SystemBuilder<Vic20System, Vic20SystemRoms, Vic20SystemConfig> for Vic20Sys
     };
 
     let memory = BranchMemory::new()
-      .map(0x0000, Box::new(low_ram))
-      .map(0x0400, Box::new(NullMemory::new()))
-      .map(0x1000, Box::new(main_ram))
-      .map(0x1E00, Box::new(vram))
-      .map(0x2000, Box::new(NullMemory::new()))
+      .map(0x0000, low_ram)
+      .map(0x0400, NullMemory::new())
+      .map(0x1000, main_ram)
+      .map(0x1E00, vram)
+      .map(0x2000, NullMemory::new())
       // .map(0x2000, Box::new(expansion_ram))
-      .map(0x8000, Box::new(characters))
-      .map(0x9000, Box::new(chip_io))
-      .map(0x9010, Box::new(NullMemory::new()))
-      .map(0x9110, Box::new(via1))
-      .map(0x9120, Box::new(via2))
-      .map(0x9130, Box::new(NullMemory::new()))
-      .map(0x9600, Box::new(colors))
-      .map(0xA000, Box::new(cartridge))
-      .map(0xC000, Box::new(basic_rom))
-      .map(0xE000, Box::new(kernel_rom));
+      .map(0x8000, characters)
+      .map(0x9000, chip_io)
+      .map(0x9010, NullMemory::new())
+      .map(0x9110, via1)
+      .map(0x9120, via2)
+      .map(0x9130, NullMemory::new())
+      .map(0x9600, colors)
+      .map(0xA000, cartridge)
+      .map(0xC000, basic_rom)
+      .map(0xE000, kernel_rom);
 
     let cpu = Mos6502::new(Box::new(memory));
 


### PR DESCRIPTION
This makes the syntax for defining a memory map much less verbose.

Old:
```
let memory = BranchMemory::new()
  .map(0x0000, Box::new(ram))
  .map(0x4000, Box::new(io))
  .map(0x8000, Box::new(rom));
```

New:
```
let memory = BranchMemory::new()
  .map(0x0000, ram)
  .map(0x4000, io)
  .map(0x8000, rom);
```

This applies to Banked and Branch memory types.

This is accomplished by using `impl` syntax, replacing `memory: Box<dyn Memory>` with `memory: impl Memory + 'static` and constructing the `Box` within the `.bank` and `.map` functions. The `'static` is needed to ensure the Box's contents live long enough.