### PR TITLE
Rework KeyState interface

### DIFF
--- a/src/keyboard/commodore.rs
+++ b/src/keyboard/commodore.rs
@@ -255,7 +255,7 @@ impl KeyAdapter<KeySymbol, C64Keys> for C64SymbolAdapter {
       })
     }
 
-    if mapped.pressed().is_empty() {
+    if mapped.is_empty() {
       // If no non-shifted keys were pressed, check for shifted keys.
       for symbol in state.pressed() {
         use KeySymbol::*;
@@ -286,7 +286,7 @@ impl KeyAdapter<KeySymbol, C64Keys> for C64SymbolAdapter {
       }
 
       // If we added keys, make sure shift is pressed
-      if !mapped.pressed().is_empty() {
+      if !mapped.is_empty() {
         mapped.press(C64Keys::LShift);
       }
     }
@@ -327,8 +327,13 @@ mod tests {
     let mapped = C64KeyboardAdapter::map(&positions);
 
     assert_eq!(
-      &vec![C64Keys::Q, C64Keys::Digit2, C64Keys::Comma, C64Keys::Return],
-      mapped.pressed()
+      vec![
+        &C64Keys::Q,
+        &C64Keys::Digit2,
+        &C64Keys::Comma,
+        &C64Keys::Return
+      ],
+      mapped.pressed().collect::<Vec<_>>()
     );
 
     positions.press(KeyPosition::LShift);
@@ -337,8 +342,13 @@ mod tests {
     let mapped = C64KeyboardAdapter::map(&positions);
 
     assert_eq!(
-      &vec![C64Keys::Q, C64Keys::Digit2, C64Keys::Comma, C64Keys::LShift],
-      mapped.pressed()
+      vec![
+        &C64Keys::Q,
+        &C64Keys::Digit2,
+        &C64Keys::Comma,
+        &C64Keys::LShift
+      ],
+      mapped.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -354,8 +364,13 @@ mod tests {
     let mapped = C64SymbolAdapter::map(&symbols);
 
     assert_eq!(
-      &vec![C64Keys::Q, C64Keys::Digit2, C64Keys::Comma, C64Keys::Return],
-      mapped.pressed()
+      vec![
+        &C64Keys::Q,
+        &C64Keys::Digit2,
+        &C64Keys::Comma,
+        &C64Keys::Return
+      ],
+      mapped.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -370,13 +385,13 @@ mod tests {
     let mapped = C64SymbolAdapter::map(&symbols);
 
     assert_eq!(
-      &vec![
-        C64Keys::Digit1,
-        C64Keys::Comma,
-        C64Keys::Period,
-        C64Keys::LShift
+      vec![
+        &C64Keys::Digit1,
+        &C64Keys::Comma,
+        &C64Keys::Period,
+        &C64Keys::LShift
       ],
-      mapped.pressed()
+      mapped.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -392,7 +407,10 @@ mod tests {
     let mapped = C64SymbolAdapter::map(&symbols);
 
     // Do a "best effort" mapping, dropping the shifted keys
-    assert_eq!(&vec![C64Keys::Digit1, C64Keys::Return], mapped.pressed());
+    assert_eq!(
+      vec![&C64Keys::Digit1, &C64Keys::Return],
+      mapped.pressed().collect::<Vec<_>>()
+    );
   }
 
   #[test]
@@ -401,32 +419,32 @@ mod tests {
 
     state.press(KeySymbol::DownArrow);
     assert_eq!(
-      &vec![C64Keys::CursorUpDown],
-      C64SymbolAdapter::map(&state).pressed()
+      vec![&C64Keys::CursorUpDown],
+      C64SymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     state.release(KeySymbol::DownArrow);
     state.press(KeySymbol::UpArrow);
     assert_eq!(
-      &vec![C64Keys::CursorUpDown, C64Keys::LShift],
-      C64SymbolAdapter::map(&state).pressed()
+      vec![&C64Keys::CursorUpDown, &C64Keys::LShift],
+      C64SymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     state.press(KeySymbol::LeftArrow);
     assert_eq!(
-      &vec![
-        C64Keys::CursorUpDown,
-        C64Keys::CursorLeftRight,
-        C64Keys::LShift
+      vec![
+        &C64Keys::CursorUpDown,
+        &C64Keys::CursorLeftRight,
+        &C64Keys::LShift
       ],
-      C64SymbolAdapter::map(&state).pressed()
+      C64SymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     // map the right arrow, but give up on the rest
     state.press(KeySymbol::RightArrow);
     assert_eq!(
-      &vec![C64Keys::CursorLeftRight],
-      C64SymbolAdapter::map(&state).pressed()
+      vec![&C64Keys::CursorLeftRight],
+      C64SymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
   }
 }

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -19,11 +19,11 @@ pub use virtualkey::VirtualKey;
 /// A set of keys that are currently pressed.
 /// Parameter `T` is the type of the key symbols.
 #[derive(Default, Debug, Clone, PartialEq)]
-pub struct KeyState<T: PartialEq> {
+pub struct KeyState<T: PartialEq + Clone> {
   pressed: Vec<T>,
 }
 
-impl<T: PartialEq> KeyState<T> {
+impl<T: PartialEq + Clone> KeyState<T> {
   /// Creates a new, empty key state.
   pub fn new() -> Self {
     Self {
@@ -42,17 +42,27 @@ impl<T: PartialEq> KeyState<T> {
   }
 
   /// Return the set of pressed keys.
-  pub fn pressed(&self) -> &Vec<T> {
-    &self.pressed
+  pub fn pressed(&self) -> impl Iterator<Item = &T> {
+    self.pressed.iter()
   }
 
   /// Returns true if the given key is currently pressed.
   pub fn is_pressed(&self, symbol: T) -> bool {
     self.pressed.contains(&symbol)
   }
+
+  /// Returns true if the set of keys is empty.
+  pub fn is_empty(&self) -> bool {
+    self.pressed.is_empty()
+  }
+
+  /// Returns the most recent key pressed.
+  pub fn get_one_key(&self) -> Option<T> {
+    self.pressed.last().cloned()
+  }
 }
 
-impl<T: PartialEq> BitOr<KeyState<T>> for KeyState<T> {
+impl<T: PartialEq + Clone> BitOr<KeyState<T>> for KeyState<T> {
   type Output = KeyState<T>;
 
   fn bitor(self, rhs: Self) -> Self::Output {
@@ -70,7 +80,7 @@ impl<T: PartialEq> BitOr<KeyState<T>> for KeyState<T> {
 /// Mappings can be symbolic (preserve symbols across the mapping, and rewrite
 /// modifier keys as needed) or physical (maintain a one-to-one mapping from
 /// physical keys to physical keys).
-pub trait KeyAdapter<F: PartialEq, T: PartialEq> {
+pub trait KeyAdapter<F: PartialEq + Clone, T: PartialEq + Clone> {
   /// Map the current state of the keyboard with symbols of type `F` to an
   /// equivalent keyboard state with symbols of type `T`.
   fn map(state: &KeyState<F>) -> KeyState<T>;

--- a/src/keyboard/symbols.rs
+++ b/src/keyboard/symbols.rs
@@ -338,13 +338,13 @@ mod tests {
 
     let symbols = SymbolAdapter::map(&positions);
     assert_eq!(
-      &vec![
-        KeySymbol::Char('b'),
-        KeySymbol::Char('m'),
-        KeySymbol::Char('c'),
+      vec![
+        &KeySymbol::Char('b'),
+        &KeySymbol::Char('m'),
+        &KeySymbol::Char('c'),
       ],
-      symbols.pressed()
-    );
+      symbols.pressed().collect::<Vec<_>>()
+    )
   }
 
   #[test]
@@ -357,12 +357,12 @@ mod tests {
 
     let symbols = SymbolAdapter::map(&positions);
     assert_eq!(
-      &vec![
-        KeySymbol::Char('B'),
-        KeySymbol::Char('M'),
-        KeySymbol::Char('C'),
+      vec![
+        &KeySymbol::Char('B'),
+        &KeySymbol::Char('M'),
+        &KeySymbol::Char('C'),
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -375,24 +375,24 @@ mod tests {
 
     let symbols = SymbolAdapter::map(&positions);
     assert_eq!(
-      &vec![
-        KeySymbol::Char('1'),
-        KeySymbol::Char('2'),
-        KeySymbol::Char('3'),
+      vec![
+        &KeySymbol::Char('1'),
+        &KeySymbol::Char('2'),
+        &KeySymbol::Char('3'),
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
 
     positions.press(KeyPosition::LShift);
 
     let symbols = SymbolAdapter::map(&positions);
     assert_eq!(
-      &vec![
-        KeySymbol::Char('!'),
-        KeySymbol::Char('@'),
-        KeySymbol::Char('#'),
+      vec![
+        &KeySymbol::Char('!'),
+        &KeySymbol::Char('@'),
+        &KeySymbol::Char('#'),
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -405,12 +405,12 @@ mod tests {
 
     let symbols = SymbolAdapter::map(&positions);
     assert_eq!(
-      &vec![
-        KeySymbol::Return,
-        KeySymbol::Backspace,
-        KeySymbol::Char(' '),
+      vec![
+        &KeySymbol::Return,
+        &KeySymbol::Backspace,
+        &KeySymbol::Char(' '),
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -441,21 +441,21 @@ mod tests {
     let symbols = SymbolAdapter::map(&positions);
 
     assert_eq!(
-      &vec![
-        KeySymbol::Char('q'),
-        KeySymbol::Char('a'),
-        KeySymbol::Char('b'),
-        KeySymbol::Char('6'),
-        KeySymbol::Char('7'),
-        KeySymbol::Char('8'),
-        KeySymbol::Char('-'),
-        KeySymbol::Char('\\'),
-        KeySymbol::Char(';'),
-        KeySymbol::Char(','),
-        KeySymbol::Return,
-        KeySymbol::LAlt,
+      vec![
+        &KeySymbol::Char('q'),
+        &KeySymbol::Char('a'),
+        &KeySymbol::Char('b'),
+        &KeySymbol::Char('6'),
+        &KeySymbol::Char('7'),
+        &KeySymbol::Char('8'),
+        &KeySymbol::Char('-'),
+        &KeySymbol::Char('\\'),
+        &KeySymbol::Char(';'),
+        &KeySymbol::Char(','),
+        &KeySymbol::Return,
+        &KeySymbol::LAlt,
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
 
     positions.press(KeyPosition::LShift);
@@ -463,21 +463,21 @@ mod tests {
     let symbols = SymbolAdapter::map(&positions);
 
     assert_eq!(
-      &vec![
-        KeySymbol::Char('Q'),
-        KeySymbol::Char('A'),
-        KeySymbol::Char('B'),
-        KeySymbol::Char('^'),
-        KeySymbol::Char('&'),
-        KeySymbol::Char('*'),
-        KeySymbol::Char('_'),
-        KeySymbol::Char('|'),
-        KeySymbol::Char(':'),
-        KeySymbol::Char('<'),
-        KeySymbol::Return,
-        KeySymbol::LAlt,
+      vec![
+        &KeySymbol::Char('Q'),
+        &KeySymbol::Char('A'),
+        &KeySymbol::Char('B'),
+        &KeySymbol::Char('^'),
+        &KeySymbol::Char('&'),
+        &KeySymbol::Char('*'),
+        &KeySymbol::Char('_'),
+        &KeySymbol::Char('|'),
+        &KeySymbol::Char(':'),
+        &KeySymbol::Char('<'),
+        &KeySymbol::Return,
+        &KeySymbol::LAlt,
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -501,12 +501,12 @@ mod tests {
     let symbols = SymbolAdapter::map(&positions);
 
     assert_eq!(
-      &vec![
-        KeySymbol::Char('b'),
-        KeySymbol::Char('m'),
-        KeySymbol::Char('c'),
+      vec![
+        &KeySymbol::Char('b'),
+        &KeySymbol::Char('m'),
+        &KeySymbol::Char('c'),
       ],
-      symbols.pressed()
+      symbols.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -519,6 +519,9 @@ mod tests {
 
     let symbols = SymbolAdapter::map(&positions);
 
-    assert_eq!(&vec![KeySymbol::Interrupt], symbols.pressed());
+    assert_eq!(
+      vec![&KeySymbol::Interrupt],
+      symbols.pressed().collect::<Vec<_>>()
+    );
   }
 }

--- a/src/systems/pet/keyboard.rs
+++ b/src/systems/pet/keyboard.rs
@@ -363,13 +363,13 @@ mod tests {
     let mapped = PetKeyboardAdapter::map(&state);
 
     assert_eq!(
-      &vec![
-        PetKeys::A,
-        PetKeys::Apostrophe,
-        PetKeys::Num9,
-        PetKeys::Semicolon,
+      vec![
+        &PetKeys::A,
+        &PetKeys::Apostrophe,
+        &PetKeys::Num9,
+        &PetKeys::Semicolon,
       ],
-      mapped.pressed()
+      mapped.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -384,8 +384,8 @@ mod tests {
     let mapped = PetSymbolAdapter::map(&state);
 
     assert_eq!(
-      &vec![PetKeys::A, PetKeys::Apostrophe, PetKeys::Num9,],
-      mapped.pressed()
+      vec![&PetKeys::A, &PetKeys::Apostrophe, &PetKeys::Num9,],
+      mapped.pressed().collect::<Vec<_>>()
     );
   }
 
@@ -397,7 +397,10 @@ mod tests {
 
     let mapped = PetSymbolAdapter::map(&state);
 
-    assert_eq!(&vec![PetKeys::DoubleQuote], mapped.pressed());
+    assert_eq!(
+      vec![&PetKeys::DoubleQuote],
+      mapped.pressed().collect::<Vec<_>>()
+    );
   }
 
   #[test]
@@ -408,13 +411,19 @@ mod tests {
     state.press(KeySymbol::Char('a'));
 
     let mapped = PetSymbolAdapter::map(&state);
-    assert_eq!(&vec![PetKeys::LShift, PetKeys::A], mapped.pressed());
+    assert_eq!(
+      vec![&PetKeys::LShift, &PetKeys::A],
+      mapped.pressed().collect::<Vec<_>>()
+    );
 
     state.release(KeySymbol::LAlt);
     state.press(KeySymbol::RAlt);
 
     let mapped = PetSymbolAdapter::map(&state);
-    assert_eq!(&vec![PetKeys::A, PetKeys::RShift], mapped.pressed());
+    assert_eq!(
+      vec![&PetKeys::A, &PetKeys::RShift],
+      mapped.pressed().collect::<Vec<_>>()
+    );
   }
 
   #[test]
@@ -423,36 +432,36 @@ mod tests {
 
     state.press(KeySymbol::DownArrow);
     assert_eq!(
-      &vec![PetKeys::CursorUpDown],
-      PetSymbolAdapter::map(&state).pressed()
+      vec![&PetKeys::CursorUpDown],
+      PetSymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     state.release(KeySymbol::DownArrow);
     state.press(KeySymbol::UpArrow);
     assert_eq!(
-      &vec![PetKeys::LShift, PetKeys::CursorUpDown],
-      PetSymbolAdapter::map(&state).pressed()
+      vec![&PetKeys::LShift, &PetKeys::CursorUpDown],
+      PetSymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     state.press(KeySymbol::LeftArrow);
     assert_eq!(
-      &vec![
-        PetKeys::LShift,
-        PetKeys::CursorUpDown,
-        PetKeys::CursorLeftRight,
+      vec![
+        &PetKeys::LShift,
+        &PetKeys::CursorUpDown,
+        &PetKeys::CursorLeftRight,
       ],
-      PetSymbolAdapter::map(&state).pressed()
+      PetSymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
 
     // map the up and left arrow, but give up on the right
     state.press(KeySymbol::RightArrow);
     assert_eq!(
-      &vec![
-        PetKeys::LShift,
-        PetKeys::CursorUpDown,
-        PetKeys::CursorLeftRight
+      vec![
+        &PetKeys::LShift,
+        &PetKeys::CursorUpDown,
+        &PetKeys::CursorLeftRight
       ],
-      PetSymbolAdapter::map(&state).pressed()
+      PetSymbolAdapter::map(&state).pressed().collect::<Vec<_>>()
     );
   }
 }


### PR DESCRIPTION
This PR reworks the `KeyState` implementation to remove the old `.pressed()` method (which previously returned the internal data structure used to track key presses) in favor of more encapsulation. Now, the `.pressed()` method returns an iterator.