### PR TITLE
Improvements to LoggingMemory

### DIFF
--- a/src/memory/logging.rs
+++ b/src/memory/logging.rs
@@ -1,0 +1,50 @@
+use super::{ActiveInterrupt, Memory, SystemInfo};
+
+pub struct LoggingMemory {
+  backing: Box<dyn Memory>,
+  message: String,
+  offset: u16,
+}
+
+impl LoggingMemory {
+  pub fn new(backing: impl Memory + 'static, message: &str, offset: u16) -> LoggingMemory {
+    LoggingMemory {
+      backing: Box::new(backing),
+      message: message.to_owned(),
+      offset,
+    }
+  }
+}
+
+impl Memory for LoggingMemory {
+  fn read(&mut self, address: u16) -> u8 {
+    let value = self.backing.read(address);
+    println!(
+      "[Memory Read]: {} address {:04X}, value {:02X}",
+      self.message,
+      address + self.offset,
+      value
+    );
+    value
+  }
+
+  fn write(&mut self, address: u16, value: u8) {
+    self.backing.write(address, value);
+    println!(
+      "[Memory Write]: {} address {:04X}, value {:02X}",
+      self.message,
+      address + self.offset,
+      value
+    );
+  }
+
+  fn reset(&mut self) {
+    self.backing.reset();
+    println!("[Memory Reset]: {}", self.message);
+  }
+
+  fn poll(&mut self, cycles: u32, info: &SystemInfo) -> ActiveInterrupt {
+    // println!("[Memory Poll]: {}", self.message);
+    self.backing.poll(cycles, info)
+  }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,6 +1,7 @@
 mod banked;
 mod block;
 mod branch;
+mod logging;
 mod mos6510;
 /// The various interface adapters (6520, 6522, 6526) for the MOS 6502 CPU.
 pub mod mos652x;
@@ -10,6 +11,7 @@ mod ports;
 pub use banked::BankedMemory;
 pub use block::BlockMemory;
 pub use branch::BranchMemory;
+pub use logging::LoggingMemory;
 pub use mos6510::Mos6510Port;
 pub use null::NullMemory;
 pub use ports::{NullPort, Port};


### PR DESCRIPTION
Re-introduce LoggingMemory, and add better logging to it (e.g. using an offset to display "true" addresses instead of relative to the start of the block).