### PR TITLE
Add an option to produce a textfile trace of instructions executed

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,7 +1,13 @@
+use crate::trace::TraceHandler;
+
 pub mod mos6502;
 
 pub trait Cpu {
+  /// Reset this CPU, clearing internal state.
   fn reset(&mut self);
+
+  /// Attach the given handler to receive trace events from this CPU.
+  fn attach_trace_handler(&mut self, trace: Box<dyn TraceHandler>);
 
   /// Return the number of cycles elapsed since the system last reset.
   fn get_cycle_count(&self) -> u64;

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,4 +14,7 @@ pub trait Cpu {
 
   /// Execute a single instruction. Return the number of cycles elapsed.
   fn tick(&mut self) -> u8;
+
+  /// Clean up any resources used by this CPU.
+  fn cleanup(&mut self) -> Result<(), &str>;
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -2,6 +2,7 @@ mod execute;
 mod fetch;
 mod registers;
 use crate::memory::{ActiveInterrupt, Memory};
+use crate::trace::TraceHandler;
 use execute::Execute;
 use fetch::Fetch;
 use registers::{flags, Registers};
@@ -25,6 +26,7 @@ pub struct Mos6502 {
   cycle_count: u64,
   cycles_since_poll: u64,
   variant: Mos6502Variant,
+  trace: Option<Box<dyn TraceHandler>>,
 }
 
 /// Read and write from the system's memory.
@@ -144,6 +146,7 @@ impl Mos6502 {
       cycle_count: 0,
       cycles_since_poll: 0,
       variant,
+      trace: None,
     }
   }
 }
@@ -159,6 +162,10 @@ impl Cpu for Mos6502 {
   /// Return a SystemInfo struct containing the current system status.
   fn get_cycle_count(&self) -> u64 {
     self.cycle_count
+  }
+
+  fn attach_trace_handler(&mut self, trace: Box<dyn TraceHandler>) {
+    self.trace = Some(trace);
   }
 
   /// Execute a single instruction.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ pub mod roms;
 /// Systems are created by a [`systems::SystemBuilder`]. A system is created with some roms, configuration, and platform. For instance, the `build` implementation on [`systems::pet::PetSystemBuilder`] takes in [`systems::pet::PetSystemRoms`], [`systems::pet::PetSystemConfig`], and an `Arc<dyn PlatformProvider>`.
 pub mod systems;
 
+/// Traces log the state of the system as it runs (e.g., to a file). This is useful for debugging.
+pub mod trace;
+
 mod time;
 
 #[cfg(target_arch = "wasm32")]

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
   cpu::Cpu,
   platform::{PlatformProvider, WindowConfig},
+  trace::TraceHandler,
 };
 use instant::Duration;
 use std::sync::Arc;
@@ -26,6 +27,10 @@ pub trait BuildableSystem<RomRegistry, SystemConfig> {
 pub trait System {
   /// Return a mutable reference to the CPU used in this system.
   fn get_cpu_mut(&mut self) -> Box<&mut dyn Cpu>;
+
+  fn attach_trace_handler(&mut self, handler: Box<dyn TraceHandler>) {
+    self.get_cpu_mut().attach_trace_handler(handler);
+  }
 
   /// Advance the system by one tick.
   fn tick(&mut self) -> Duration;

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -43,6 +43,6 @@ pub trait System {
 
   /// Clean up any resources used by this system.
   fn cleanup(&mut self) -> Result<(), &str> {
-    Ok(())
+    self.get_cpu_mut().cleanup()
   }
 }

--- a/src/trace/file.rs
+++ b/src/trace/file.rs
@@ -1,0 +1,23 @@
+use crate::trace::{CpuTrace, TraceHandler};
+use std::{fs::File, io::Write};
+
+pub struct FileTraceHandler {
+  file: File,
+}
+
+impl FileTraceHandler {
+  pub fn new(filename: String) -> Self {
+    Self {
+      file: File::create(filename).expect("Invalid filename"),
+    }
+  }
+}
+
+impl TraceHandler for FileTraceHandler {
+  fn handle(&mut self, trace: &CpuTrace) {
+    self
+      .file
+      .write_all(format!("{:04X}: {:02X}\n", trace.address, trace.opcode).as_bytes())
+      .unwrap();
+  }
+}

--- a/src/trace/file.rs
+++ b/src/trace/file.rs
@@ -1,14 +1,17 @@
 use crate::trace::{CpuTrace, TraceHandler};
-use std::{fs::File, io::Write};
+use std::{
+  fs::File,
+  io::{BufWriter, Write},
+};
 
 pub struct FileTraceHandler {
-  file: File,
+  file: BufWriter<File>,
 }
 
 impl FileTraceHandler {
   pub fn new(filename: String) -> Self {
     Self {
-      file: File::create(filename).expect("Invalid filename"),
+      file: BufWriter::new(File::create(filename).expect("Invalid filename")),
     }
   }
 }
@@ -19,5 +22,9 @@ impl TraceHandler for FileTraceHandler {
       .file
       .write_all(format!("{:04X}: {:02X}\n", trace.address, trace.opcode).as_bytes())
       .unwrap();
+  }
+
+  fn flush(&mut self) -> Result<(), &str> {
+    self.file.flush().map_err(|_| "failed to flush file")
   }
 }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -13,5 +13,7 @@ pub trait TraceHandler {
   fn handle(&mut self, trace: &CpuTrace);
 
   /// Flush any existing resource buffers.
-  fn flush(&mut self) -> Result<(), &str>{ Ok(())}
+  fn flush(&mut self) -> Result<(), &str> {
+    Ok(())
+  }
 }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -11,4 +11,7 @@ pub struct CpuTrace {
 pub trait TraceHandler {
   /// Handle a trace event.
   fn handle(&mut self, trace: &CpuTrace);
+
+  /// Flush any existing resource buffers.
+  fn flush(&mut self) -> Result<(), &str>{ Ok(())}
 }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -1,0 +1,14 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod file;
+
+/// Trace information provided after each instruction by the CPU.
+pub struct CpuTrace {
+  pub address: u16,
+  pub opcode: u8,
+}
+
+/// An item which can handle a CPU trace (e.g. logging to a file)
+pub trait TraceHandler {
+  /// Handle a trace event.
+  fn handle(&mut self, trace: &CpuTrace);
+}


### PR DESCRIPTION
Useful for debugging.

Adds infrastructure as well in case we want to make the trace more detailed in the future, make other kinds of trace handlers, etc.